### PR TITLE
Add combined frontend/backend dev workflow and clarify local URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ http://localhost:3000
 
 Set `NEXT_PUBLIC_API_BASE_URL` if the API is not running on `http://localhost:8000`.
 
+## Run Frontend + Backend Together
+
+```bash
+npm run dev:all
+```
+
+- Frontend (3D astronaut model): `http://localhost:3000`
+- Backend API JSON: `http://localhost:8000`
+
+If you open port `8000`, you will see API JSON (health/docs), not the 3D scene.
+
 ## Run the Backend
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev apps/web -p 3000",
     "web:dev": "next dev apps/web -p 3000",
     "api:dev": "bash ./scripts/dev.sh",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "dev:all": "bash ./scripts/dev-full.sh"
   },
   "dependencies": {
     "@react-three/fiber": "^9.1.0",

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cleanup() {
+  if [[ -n "${API_PID:-}" ]] && kill -0 "$API_PID" 2>/dev/null; then
+    kill "$API_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+bash "$ROOT_DIR/scripts/dev.sh" &
+API_PID=$!
+
+cd "$ROOT_DIR"
+exec next dev apps/web -p 3000


### PR DESCRIPTION
### Motivation
- Provide a single, convenience command to run the FastAPI backend and Next.js frontend together to avoid confusion when users open the API port and only see JSON.
- Clarify local URLs in the README so it's explicit that the 3D scene is served on port `3000` and the API JSON on port `8000`.

### Description
- Add `scripts/dev-full.sh` which launches the API in the background (via `scripts/dev.sh`) and then runs `next dev apps/web -p 3000`, with a cleanup trap to kill the API process on exit. 
- Add a root npm script `dev:all` in `package.json` that runs `bash ./scripts/dev-full.sh` so both services can be started with `npm run dev:all`.
- Update `README.md` to document the combined dev command and explicitly note that `http://localhost:3000` serves the 3D frontend and `http://localhost:8000` serves API JSON (health/docs).

### Testing
- Ran `npm run typecheck` which currently fails due to existing TypeScript/dependency issues unrelated to this patch (the failure pre-existed and is not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cabf9acc832ea88544f2aaec2e50)