### PR TITLE
change Earth, create starting animation, some artistic expression at …

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ The frontend `mapQuantumToBody.ts` normalizes that JSON into body region state a
 ```bash
 docker compose up --build
 ```
+
+## Music Credit
+
+Song: Eden  
+Composer: Onycs  
+Website: https://www.youtube.com/channel/UCNQ6vKZ5ogEZ0tM2TvxLhQA  
+License: Creative Commons (BY 3.0) https://creativecommons.org/licenses/by/3.0/  
+Music powered by BreakingCopyright: https://breakingcopyright.com

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -19,30 +19,146 @@ button {
   font: inherit;
 }
 
-.scene-title {
+.background-music {
   position: fixed;
-  left: 50%;
-  top: 30px;
-  z-index: 14;
-  display: grid;
-  gap: 16px;
-  width: min(760px, calc(100vw - 32px));
+  left: 0;
+  bottom: 0;
+  z-index: -1;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  opacity: 0;
   pointer-events: none;
+}
+
+.loading-intro {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: #000;
+  color: #fff;
+  opacity: 1;
+  transition: opacity 1800ms ease;
+}
+
+.loading-intro--exiting {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-intro__stars {
+  position: absolute;
+  inset: 0;
+}
+
+.loading-intro__stars i {
+  position: absolute;
+  display: block;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.72);
+  animation: star-pulse 3s ease-in-out infinite;
+}
+
+.loading-intro__copy {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 22px;
+  width: min(920px, calc(100vw - 40px));
+  min-height: 180px;
+  place-items: center;
+  padding: 0 20px;
   text-align: center;
-  transform: translateX(-50%);
 }
 
-.scene-title__name {
-  font-size: 84px;
+.loading-intro__copy p {
+  min-height: 94px;
+  margin: 0;
+  font-family: "Courier New", monospace;
+  font-size: 34px;
+  font-weight: 700;
+  line-height: 1.38;
+  text-wrap: balance;
+}
+
+.loading-intro__copy--title {
+  width: min(1180px, calc(100vw - 32px));
+  min-height: 300px;
+}
+
+.loading-intro__copy--title p {
+  display: grid;
+  gap: 20px;
+  min-height: 210px;
+  place-items: center;
+}
+
+.loading-intro__title-line {
+  display: block;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 132px;
   font-weight: 900;
-  line-height: 0.95;
-  letter-spacing: 0;
+  line-height: 0.92;
 }
 
-.scene-title__subtitle {
-  color: rgba(245, 247, 251, 0.68);
-  font-size: 36px;
-  line-height: 1.1;
+.loading-intro__subtitle-line {
+  display: block;
+  color: rgba(255, 255, 255, 0.76);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 54px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.loading-intro__cursor {
+  display: inline-block;
+  width: 0.62em;
+  height: 1em;
+  margin-left: 4px;
+  border-right: 2px solid rgba(255, 255, 255, 0.94);
+  vertical-align: -0.16em;
+  animation: cursor-blink 860ms steps(1) infinite;
+}
+
+.loading-intro__hint {
+  padding: 7px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.68);
+  font-family: "Courier New", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+@keyframes star-pulse {
+  0%,
+  100% {
+    transform: scale(0.72);
+    filter: brightness(0.72);
+  }
+
+  50% {
+    transform: scale(1.18);
+    filter: brightness(1.36);
+  }
+}
+
+@keyframes cursor-blink {
+  0%,
+  48% {
+    opacity: 1;
+  }
+
+  49%,
+  100% {
+    opacity: 0;
+  }
 }
 
 .scene-status {
@@ -176,6 +292,35 @@ button {
   border: 1px solid rgba(135, 230, 255, 0.18);
   border-radius: 6px;
   background: rgba(135, 230, 255, 0.06);
+}
+
+.quantum-dashboard__story {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(196, 223, 255, 0.14);
+}
+
+.quantum-dashboard__story p {
+  margin: 0;
+  color: rgba(245, 247, 251, 0.74);
+  font-size: 13px;
+  line-height: 1.48;
+}
+
+.quantum-dashboard__science {
+  display: grid;
+  gap: 8px;
+  padding: 11px;
+  border: 1px solid rgba(133, 241, 189, 0.18);
+  border-radius: 6px;
+  background: rgba(133, 241, 189, 0.055);
+}
+
+.quantum-dashboard__science p {
+  color: rgba(245, 247, 251, 0.66);
+  font-size: 12px;
 }
 
 .quantum-dashboard__scene-status-header,
@@ -396,6 +541,10 @@ button {
   font-size: 12px;
 }
 
+.quantum-dashboard__node-row--compact {
+  grid-template-columns: minmax(0, 1fr) 24px;
+}
+
 .quantum-dashboard__node-row span,
 .quantum-dashboard__node-row i {
   overflow: hidden;
@@ -491,19 +640,6 @@ button {
 }
 
 @media (max-width: 920px) {
-  .scene-title {
-    top: 18px;
-    gap: 8px;
-  }
-
-  .scene-title__name {
-    font-size: 42px;
-  }
-
-  .scene-title__subtitle {
-    font-size: 16px;
-  }
-
   .scene-status {
     left: 16px;
     bottom: calc(48vh + 28px);
@@ -539,5 +675,32 @@ button {
 
   .quantum-node-overlay__bit {
     font-size: 18px;
+  }
+
+  .loading-intro__copy {
+    min-height: 150px;
+  }
+
+  .loading-intro__copy p {
+    min-height: 86px;
+    font-size: 22px;
+    line-height: 1.46;
+  }
+
+  .loading-intro__copy--title {
+    min-height: 220px;
+  }
+
+  .loading-intro__copy--title p {
+    min-height: 150px;
+    gap: 12px;
+  }
+
+  .loading-intro__title-line {
+    font-size: 54px;
+  }
+
+  .loading-intro__subtitle-line {
+    font-size: 24px;
   }
 }

--- a/apps/web/components/BackgroundMusic.tsx
+++ b/apps/web/components/BackgroundMusic.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const BACKGROUND_MUSIC_URL = "/audios/Onycs%20-%20Eden.mp3";
+
+type BackgroundMusicProps = {
+  playing: boolean;
+};
+
+export function BackgroundMusic({ playing }: BackgroundMusicProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (!playing) {
+      audio.pause();
+      return;
+    }
+
+    audio.volume = 0.42;
+    void audio.play();
+  }, [playing]);
+
+  return (
+    <audio
+      ref={audioRef}
+      className="background-music"
+      src={BACKGROUND_MUSIC_URL}
+      loop
+      preload="auto"
+      aria-hidden="true"
+    />
+  );
+}

--- a/apps/web/components/BodyScene.tsx
+++ b/apps/web/components/BodyScene.tsx
@@ -7,7 +7,9 @@ import type { Vector3Tuple } from "three";
 import { emptyRegionStates, type BodyQuantumState, type BodyRegion } from "../lib/bodyRegions";
 import { mapQuantumToBody } from "../lib/mapQuantumToBody";
 import { getPrecomputed, measure, type QuantumMeasurementPayload } from "../lib/quantumClient";
+import { BackgroundMusic } from "./BackgroundMusic";
 import { CameraControls } from "./CameraControls";
+import { LoadingIntro } from "./LoadingIntro";
 import { OriginalGlbModel } from "./OriginalGlbModel";
 import { QuantumNodeDashboard } from "./QuantumNodeDashboard";
 import { SpaceEnvironment } from "./SpaceEnvironment";
@@ -38,23 +40,56 @@ export function BodyScene() {
   const [hoveredRegion, setHoveredRegion] = useState<BodyRegion | null>(null);
   const [hoveredPoint, setHoveredPoint] = useState<Vector3Tuple | null>(null);
   const [modelStable, setModelStable] = useState(false);
+  const [modelReady, setModelReady] = useState(false);
+  const [introComplete, setIntroComplete] = useState(false);
+  const [musicPlaying, setMusicPlaying] = useState(false);
   const [stablePoint, setStablePoint] = useState<Vector3Tuple | null>(null);
   const [stableProgress, setStableProgress] = useState(0);
+  const [connectionBreakPoint, setConnectionBreakPoint] = useState<Vector3Tuple | null>(null);
+  const [connectionBreakProgress, setConnectionBreakProgress] = useState(0);
   const [inspectedNode, setInspectedNode] = useState<InspectedNode | null>(null);
   const precomputedCache = useRef(new Map<BodyRegion, BodyQuantumState>());
   const lastHoverRegion = useRef<BodyRegion | null>(null);
   const collapseFrame = useRef<number | null>(null);
+  const connectionBreakFrame = useRef<number | null>(null);
+  const stableReturnFrame = useRef<number | null>(null);
   const stableReturnTimeout = useRef<number | null>(null);
+  const collapseLocked = modelStable || collapseFrame.current !== null || stableReturnTimeout.current !== null || stableReturnFrame.current !== null;
 
   useEffect(() => {
     return () => {
       if (collapseFrame.current !== null) cancelAnimationFrame(collapseFrame.current);
+      if (connectionBreakFrame.current !== null) cancelAnimationFrame(connectionBreakFrame.current);
+      if (stableReturnFrame.current !== null) cancelAnimationFrame(stableReturnFrame.current);
       if (stableReturnTimeout.current !== null) window.clearTimeout(stableReturnTimeout.current);
     };
   }, []);
 
+  const startConnectionBreakAnimation = useCallback((point?: Vector3Tuple) => {
+    if (connectionBreakFrame.current !== null) cancelAnimationFrame(connectionBreakFrame.current);
+    setConnectionBreakPoint(point ?? hoveredPoint);
+    setConnectionBreakProgress(0);
+
+    const started = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - started) / 1300);
+      setConnectionBreakProgress(progress);
+      if (progress < 1) {
+        connectionBreakFrame.current = requestAnimationFrame(tick);
+      } else {
+        connectionBreakFrame.current = null;
+      }
+    };
+
+    connectionBreakFrame.current = requestAnimationFrame(tick);
+  }, [hoveredPoint]);
+
   const startCollapseAnimation = useCallback((point?: Vector3Tuple) => {
     if (collapseFrame.current !== null) cancelAnimationFrame(collapseFrame.current);
+    if (stableReturnFrame.current !== null) {
+      cancelAnimationFrame(stableReturnFrame.current);
+      stableReturnFrame.current = null;
+    }
     if (stableReturnTimeout.current !== null) {
       window.clearTimeout(stableReturnTimeout.current);
       stableReturnTimeout.current = null;
@@ -74,6 +109,33 @@ export function BodyScene() {
         collapseFrame.current = requestAnimationFrame(tick);
       } else {
         collapseFrame.current = null;
+        stableReturnTimeout.current = window.setTimeout(() => {
+          stableReturnTimeout.current = null;
+          const returnStarted = performance.now();
+          const returnTick = (returnNow: number) => {
+            const returnProgress = Math.min(1, (returnNow - returnStarted) / 2600);
+            const reverseProgress = 1 - returnProgress;
+
+            setStableProgress(reverseProgress);
+            setCollapseProgress(reverseProgress);
+            setConnectionBreakProgress(reverseProgress);
+
+            if (returnProgress < 1) {
+              stableReturnFrame.current = requestAnimationFrame(returnTick);
+            } else {
+              stableReturnFrame.current = null;
+              setMode("superposition");
+              setCollapseProgress(0);
+              setModelStable(false);
+              setStablePoint(null);
+              setStableProgress(0);
+              setConnectionBreakPoint(null);
+              setConnectionBreakProgress(0);
+            }
+          };
+
+          stableReturnFrame.current = requestAnimationFrame(returnTick);
+        }, 3400);
       }
     };
 
@@ -86,6 +148,10 @@ export function BodyScene() {
     if (modelStable) return;
     if (!region) {
       lastHoverRegion.current = null;
+      if (connectionBreakFrame.current === null) {
+        setConnectionBreakPoint(null);
+        setConnectionBreakProgress(0);
+      }
       return;
     }
 
@@ -139,7 +205,7 @@ export function BodyScene() {
   }, [hoveredPoint, loading]);
 
   const triggerGlobalCollapse = useCallback(async (region?: BodyRegion, point?: Vector3Tuple) => {
-    if (loading) return;
+    if (loading || collapseLocked) return;
 
     try {
       setLoading(true);
@@ -147,6 +213,7 @@ export function BodyScene() {
       setInspectedNode(null);
       setHoveredRegion(region ?? hoveredRegion);
       setHoveredPoint(point ?? hoveredPoint);
+      startConnectionBreakAnimation(point);
       startCollapseAnimation(point);
       const payload = await measure(region ?? hoveredRegion ?? "torso", 1, 1024, { interaction: "hold" });
       const mapped = mapQuantumToBody(payload);
@@ -157,7 +224,7 @@ export function BodyScene() {
     } finally {
       setLoading(false);
     }
-  }, [hoveredPoint, hoveredRegion, loading, startCollapseAnimation]);
+  }, [collapseLocked, hoveredPoint, hoveredRegion, loading, startCollapseAnimation, startConnectionBreakAnimation]);
 
   const applyStrongMeasurement = useCallback((region: BodyRegion, point?: Vector3Tuple, nodeIndex?: number) => {
     if (appMode === "inspect") {
@@ -173,16 +240,34 @@ export function BodyScene() {
     void triggerGlobalCollapse();
   }, [appMode, triggerGlobalCollapse]);
 
+  const handleModelReady = useCallback(() => {
+    setModelReady(true);
+  }, []);
+
+  const handleIntroComplete = useCallback(() => {
+    setIntroComplete(true);
+  }, []);
+
+  const handleIntroExitStart = useCallback(() => {
+    setMusicPlaying(true);
+  }, []);
+
   const switchAppMode = useCallback((nextMode: AppMode) => {
     setAppMode(nextMode);
     setError(null);
     setInspectedNode(null);
     if (nextMode === "inspect") {
+      if (connectionBreakFrame.current !== null) {
+        cancelAnimationFrame(connectionBreakFrame.current);
+        connectionBreakFrame.current = null;
+      }
       setMode("superposition");
       setCollapseProgress(0);
       setModelStable(false);
       setStablePoint(null);
       setStableProgress(0);
+      setConnectionBreakPoint(null);
+      setConnectionBreakProgress(0);
     }
   }, []);
 
@@ -194,7 +279,7 @@ export function BodyScene() {
         <directionalLight position={[2.6, 4.2, 3.4]} intensity={1.85} />
         <directionalLight position={[-2.2, 1.4, 2.4]} intensity={0.72} color="#bfe8ff" />
         <pointLight position={[-2.4, 1.2, 2.2]} intensity={0.72} color="#85d8ff" />
-        <SpaceEnvironment />
+        <SpaceEnvironment sunOcclusion={modelStable ? stableProgress : 0} />
         <group rotation={[0, -0.08, 0]}>
           <OriginalGlbModel
             modelUrl={MODEL_URL}
@@ -203,19 +288,18 @@ export function BodyScene() {
             onHoverRegion={applyWeakMeasurement}
             onMeasureRegion={applyStrongMeasurement}
             onGlobalCollapse={handleGlobalCollapse}
+            onReady={handleModelReady}
             stable={modelStable}
             stablePoint={stablePoint}
             stableProgress={stableProgress}
+            connectionBreakPoint={connectionBreakPoint}
+            connectionBreakProgress={connectionBreakProgress}
             opacity={0.22}
             waveStrength={0}
           />
         </group>
         <CameraControls />
       </Canvas>
-      <div className="scene-title" aria-hidden="true">
-        <div className="scene-title__name">Entangled Body</div>
-        <div className="scene-title__subtitle">original GLB | transparent wave | hold collapse</div>
-      </div>
       <div className="scene-mode-switch" aria-label="Interaction mode">
         <button type="button" className={appMode === "inspect" ? "scene-mode-switch__button scene-mode-switch__button--active" : "scene-mode-switch__button"} onClick={() => switchAppMode("inspect")}>
           Inspect
@@ -224,6 +308,8 @@ export function BodyScene() {
           Measurement
         </button>
       </div>
+      <LoadingIntro modelReady={modelReady} onComplete={handleIntroComplete} onExitStart={handleIntroExitStart} visible={!introComplete} />
+      <BackgroundMusic playing={musicPlaying} />
       {error ? <div className="scene-status" role="status" aria-live="polite">{error}</div> : null}
       <QuantumNodeDashboard
         latestMeasurement={latestMeasurement}

--- a/apps/web/components/LoadingIntro.tsx
+++ b/apps/web/components/LoadingIntro.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+
+const INTRO_LINES = [
+  "Everything is in a quantum state.",
+  "Before form, there is only possibility.",
+  "Nothing is fixed until it is observed.",
+  "A signal moves through the invisible field.",
+  "The body is not loading; it is becoming.",
+  "Entangled Body\nmeasure our project.",
+];
+const INTRO_FADE_OUT_MS = 1800;
+
+type LoadingIntroProps = {
+  modelReady: boolean;
+  onComplete: () => void;
+  onExitStart?: () => void;
+  visible: boolean;
+};
+
+export function LoadingIntro({ modelReady, onComplete, onExitStart, visible }: LoadingIntroProps) {
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const [exiting, setExiting] = useState(false);
+  const [lineIndex, setLineIndex] = useState(0);
+  const [typedLength, setTypedLength] = useState(0);
+  const currentLine = INTRO_LINES[lineIndex];
+  const stars = useMemo(
+    () =>
+      Array.from({ length: 90 }, (_, index) => ({
+        id: index,
+        left: `${(index * 37) % 100}%`,
+        top: `${(index * 61) % 100}%`,
+        delay: `${((index * 13) % 30) / 10}s`,
+        duration: `${2.2 + ((index * 7) % 18) / 10}s`,
+        size: `${1 + (index % 3)}px`,
+        opacity: 0.34 + ((index * 11) % 50) / 100,
+      })),
+    [],
+  );
+
+  useEffect(() => {
+    if (!visible) return;
+    setExiting(false);
+    setLineIndex(0);
+    setTypedLength(0);
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (typedLength >= currentLine.length) return;
+
+    const timeout = window.setTimeout(() => {
+      setTypedLength((length) => Math.min(currentLine.length, length + 1));
+      playTypingTick(audioContextRef);
+    }, 34);
+
+    return () => window.clearTimeout(timeout);
+  }, [currentLine, typedLength, visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Enter") return;
+      event.preventDefault();
+      void resumeTypingAudio(audioContextRef);
+
+      if (typedLength < currentLine.length) {
+        setTypedLength(currentLine.length);
+        return;
+      }
+
+      if (lineIndex >= INTRO_LINES.length - 1) {
+        if (modelReady && !exiting) {
+          onExitStart?.();
+          setExiting(true);
+          window.setTimeout(onComplete, INTRO_FADE_OUT_MS);
+        }
+        return;
+      }
+
+      setLineIndex((index) => index + 1);
+      setTypedLength(0);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [currentLine.length, exiting, lineIndex, modelReady, onComplete, onExitStart, typedLength, visible]);
+
+  if (!visible) return null;
+  const isTitleLine = lineIndex === INTRO_LINES.length - 1;
+  const visibleTitle = currentLine.slice(0, typedLength);
+  const hasSubtitleStarted = visibleTitle.includes("\n");
+  const [title, subtitle = ""] = visibleTitle.split("\n");
+
+  return (
+    <section className={exiting ? "loading-intro loading-intro--exiting" : "loading-intro"} aria-live="polite" aria-label="3D model loading introduction">
+      <div className="loading-intro__stars" aria-hidden="true">
+        {stars.map((star) => (
+          <i
+            key={star.id}
+            style={{
+              left: star.left,
+              top: star.top,
+              width: star.size,
+              height: star.size,
+              opacity: star.opacity,
+              animationDelay: star.delay,
+              animationDuration: star.duration,
+            }}
+          />
+        ))}
+      </div>
+      <div className={isTitleLine ? "loading-intro__copy loading-intro__copy--title" : "loading-intro__copy"}>
+        {isTitleLine ? (
+          <p>
+            <span className="loading-intro__title-line">
+              {title}
+              {!hasSubtitleStarted ? <span aria-hidden="true" className="loading-intro__cursor" /> : null}
+            </span>
+            {hasSubtitleStarted ? (
+              <span className="loading-intro__subtitle-line">
+                {subtitle}
+                <span aria-hidden="true" className="loading-intro__cursor" />
+              </span>
+            ) : null}
+          </p>
+        ) : (
+          <p>
+            {currentLine.slice(0, typedLength)}
+            <span aria-hidden="true" className="loading-intro__cursor" />
+          </p>
+        )}
+        <span className="loading-intro__hint">{lineIndex >= INTRO_LINES.length - 1 && !modelReady ? "Rendering" : "Enter"}</span>
+      </div>
+    </section>
+  );
+}
+
+type WindowWithWebkitAudio = Window &
+  typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+  };
+
+function getTypingAudioContext(audioContextRef: MutableRefObject<AudioContext | null>) {
+  if (audioContextRef.current) return audioContextRef.current;
+
+  const audioWindow = window as WindowWithWebkitAudio;
+  const AudioContextConstructor = audioWindow.AudioContext || audioWindow.webkitAudioContext;
+  if (!AudioContextConstructor) return null;
+
+  const audioContext = new AudioContextConstructor();
+  audioContextRef.current = audioContext;
+  return audioContext;
+}
+
+async function resumeTypingAudio(audioContextRef: MutableRefObject<AudioContext | null>) {
+  const audioContext = getTypingAudioContext(audioContextRef);
+  if (!audioContext || audioContext.state !== "suspended") return;
+  await audioContext.resume();
+}
+
+function playTypingTick(audioContextRef: MutableRefObject<AudioContext | null>) {
+  const audioContext = getTypingAudioContext(audioContextRef);
+  if (!audioContext || audioContext.state !== "running") return;
+
+  const now = audioContext.currentTime;
+  const duration = 0.045;
+  const sampleCount = Math.floor(audioContext.sampleRate * duration);
+  const buffer = audioContext.createBuffer(1, sampleCount, audioContext.sampleRate);
+  const samples = buffer.getChannelData(0);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const progress = index / sampleCount;
+    const envelope = Math.pow(1 - progress, 5);
+    samples[index] = (Math.random() * 2 - 1) * envelope;
+  }
+
+  const source = audioContext.createBufferSource();
+  const filter = audioContext.createBiquadFilter();
+  const gain = audioContext.createGain();
+
+  source.buffer = buffer;
+  filter.type = "bandpass";
+  filter.frequency.setValueAtTime(1650 + Math.random() * 260, now);
+  filter.Q.setValueAtTime(5.5, now);
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.09, now + 0.004);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+  source.connect(filter);
+  filter.connect(gain);
+  gain.connect(audioContext.destination);
+  source.start(now);
+  source.stop(now + duration);
+}

--- a/apps/web/components/OriginalGlbModel.tsx
+++ b/apps/web/components/OriginalGlbModel.tsx
@@ -29,9 +29,12 @@ type OriginalGlbModelProps = {
   onHoverRegion: (region: BodyRegion | null, point?: Vector3Tuple) => void;
   onMeasureRegion: (region: BodyRegion, point?: Vector3Tuple, nodeIndex?: number) => void;
   onGlobalCollapse: () => void;
+  onReady?: () => void;
   stable: boolean;
   stablePoint: Vector3Tuple | null;
   stableProgress: number;
+  connectionBreakPoint: Vector3Tuple | null;
+  connectionBreakProgress: number;
   opacity?: number;
   waveStrength?: number;
 };
@@ -122,9 +125,12 @@ export function OriginalGlbModel({
   onHoverRegion,
   onMeasureRegion,
   onGlobalCollapse,
+  onReady,
   stable,
   stablePoint,
   stableProgress,
+  connectionBreakPoint,
+  connectionBreakProgress,
   opacity = 0.34,
   waveStrength = 1,
 }: OriginalGlbModelProps) {
@@ -179,12 +185,13 @@ export function OriginalGlbModel({
         maxZ: box.max.z,
         position: [-center.x * scale, GROUND_Y - box.min.y * scale, -center.z * scale],
       });
+      onReady?.();
     });
 
     return () => {
       cancelled = true;
     };
-  }, [modelUrl, opacity]);
+  }, [modelUrl, onReady, opacity]);
 
   useEffect(() => {
     return () => {
@@ -245,7 +252,9 @@ export function OriginalGlbModel({
   const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
   const surfaceGlowOpacity = (hasSurfaceInteraction ? 0.34 : 0.05) * surfaceFade;
   const surfacePointOpacity = (hasSurfaceInteraction ? 0.34 : 0.68) * surfaceFade;
-  const activeFixedPointSource = stable && stablePoint ? stablePoint : hoveredPoint;
+  const activeFixedPointSource = connectionBreakPoint ?? (stable && stablePoint ? stablePoint : hoveredPoint);
+  const showFullEntanglement = Boolean(hoveredPoint || connectionBreakPoint || stablePoint);
+  const disconnectEntanglement = Boolean(connectionBreakPoint);
 
   function clearHoldTimer() {
     if (holdTimer.current === null) return;
@@ -276,7 +285,14 @@ export function OriginalGlbModel({
           </points>
         </>
       ) : null}
-      <FixedRegionPoints model={model} interactionPoint={activeFixedPointSource} connectAll={stable && Boolean(stablePoint)} connectionProgress={stableProgress} />
+      <FixedRegionPoints
+        model={model}
+        interactionPoint={activeFixedPointSource}
+        connectAll={showFullEntanglement}
+        connectionProgress={disconnectEntanglement ? connectionBreakProgress : 1}
+        disconnect={disconnectEntanglement}
+        pointOpacity={disconnectEntanglement ? 1 - connectionBreakProgress : 1}
+      />
       <primitive
         object={model.scene}
         onPointerMove={(event: ThreeEvent<PointerEvent>) => {
@@ -315,16 +331,20 @@ function FixedRegionPoints({
   interactionPoint,
   connectAll,
   connectionProgress,
+  disconnect,
+  pointOpacity,
 }: {
   model: LoadedModel;
   interactionPoint: Vector3Tuple | null;
   connectAll: boolean;
   connectionProgress: number;
+  disconnect: boolean;
+  pointOpacity: number;
 }) {
   const points = useMemo(() => getFixedRegionPoints(model), [model]);
   const networkGeometry = useMemo(
-    () => createFixedRegionNetworkGeometry(points, model.scene, interactionPoint, connectAll, connectionProgress),
-    [connectAll, connectionProgress, interactionPoint, model.scene, points],
+    () => createFixedRegionNetworkGeometry(points, model.scene, interactionPoint, connectAll, connectionProgress, disconnect),
+    [connectAll, connectionProgress, disconnect, interactionPoint, model.scene, points],
   );
 
   return (
@@ -339,18 +359,20 @@ function FixedRegionPoints({
           </lineSegments>
         </>
       ) : null}
-      {points.map((point) => (
-        <group key={point.label} position={point.position}>
-          <mesh renderOrder={40} raycast={ignorePointRaycast}>
-            <sphereGeometry args={[0.026, 16, 16]} />
-            <meshBasicMaterial color="#9beaff" transparent opacity={0.96} depthTest={false} depthWrite={false} toneMapped={false} />
-          </mesh>
-          <mesh renderOrder={39} raycast={ignorePointRaycast}>
-            <sphereGeometry args={[0.072, 16, 16]} />
-            <meshBasicMaterial color="#1fbfff" transparent opacity={0.22} blending={AdditiveBlending} depthTest={false} depthWrite={false} toneMapped={false} />
-          </mesh>
-        </group>
-      ))}
+      {pointOpacity > 0.001
+        ? points.map((point) => (
+            <group key={point.label} position={point.position}>
+              <mesh renderOrder={40} raycast={ignorePointRaycast}>
+                <sphereGeometry args={[0.026, 16, 16]} />
+                <meshBasicMaterial color="#9beaff" transparent opacity={0.96 * pointOpacity} depthTest={false} depthWrite={false} toneMapped={false} />
+              </mesh>
+              <mesh renderOrder={39} raycast={ignorePointRaycast}>
+                <sphereGeometry args={[0.072, 16, 16]} />
+                <meshBasicMaterial color="#1fbfff" transparent opacity={0.22 * pointOpacity} blending={AdditiveBlending} depthTest={false} depthWrite={false} toneMapped={false} />
+              </mesh>
+            </group>
+          ))
+        : null}
     </group>
   );
 }
@@ -390,12 +412,13 @@ function createFixedRegionNetworkGeometry(
   interactionPoint: Vector3Tuple | null,
   connectAll: boolean,
   connectionProgress: number,
+  disconnect: boolean,
 ): BufferGeometry | null {
   const segments: number[] = [];
 
   if (connectAll) {
     const source = interactionPoint ? findNearestFixedRegionPointFromWorld(points, scene, interactionPoint) : null;
-    pushAllFixedRegionConnections(segments, points, connectionProgress, source);
+    pushAllFixedRegionConnections(segments, points, connectionProgress, source, disconnect);
   } else {
     const path = getFixedRegionPath(points, scene, interactionPoint);
     if (path.length < 2) return null;
@@ -428,7 +451,13 @@ function getFixedRegionPath(points: FixedRegionPoint[], scene: Object3D, interac
   return [source, firstTarget, secondTarget, thirdTarget].filter((point): point is FixedRegionPoint => Boolean(point));
 }
 
-function pushAllFixedRegionConnections(segments: number[], points: FixedRegionPoint[], connectionProgress: number, source: FixedRegionPoint | null): void {
+function pushAllFixedRegionConnections(
+  segments: number[],
+  points: FixedRegionPoint[],
+  connectionProgress: number,
+  source: FixedRegionPoint | null,
+  disconnect: boolean,
+): void {
   const pointByLabel = new Map(points.map((point) => [point.label, point]));
   const usedEdges = new Set<string>();
   const edges: Array<[FixedRegionPoint, FixedRegionPoint]> = [];
@@ -451,9 +480,11 @@ function pushAllFixedRegionConnections(segments: number[], points: FixedRegionPo
     const rightScore = fixedRegionRevealScore(right[0], right[1], graphDistances);
     return leftScore - rightScore;
   });
-  const visibleEdgeCount = Math.min(orderedEdges.length, Math.ceil(orderedEdges.length * Math.max(0, Math.min(1, connectionProgress))));
+  const progress = Math.max(0, Math.min(1, connectionProgress));
+  const hiddenEdgeCount = disconnect ? Math.floor(orderedEdges.length * progress) : 0;
+  const visibleEdgeCount = disconnect ? orderedEdges.length : Math.min(orderedEdges.length, Math.ceil(orderedEdges.length * progress));
 
-  for (let index = 0; index < visibleEdgeCount; index += 1) {
+  for (let index = hiddenEdgeCount; index < visibleEdgeCount; index += 1) {
     pushFixedRegionSegment(segments, orderedEdges[index][0], orderedEdges[index][1]);
   }
 }

--- a/apps/web/components/QuantumNodeDashboard.tsx
+++ b/apps/web/components/QuantumNodeDashboard.tsx
@@ -39,6 +39,176 @@ const QUANTUM_NODE_LABELS = [
   "Left Foot",
 ];
 
+type ModeCopy = {
+  eyebrow: string;
+  title: string;
+  metaphor: string;
+  science: string;
+};
+
+const MODE_COPY: { measurement: ModeCopy } = {
+  measurement: {
+    eyebrow: "Global Collapse",
+    title: "When the Field Chooses a Shape",
+    metaphor:
+      "The body is held between many possible arrangements until measurement turns uncertainty into one visible state. Lines, bits, and motion become a record of that decision.",
+    science:
+      "Measurement mode sends a stronger interaction to the quantum simulator. Multiple shots sample a six-qubit circuit, producing count distributions and a dominant bitstring that are mapped back into activation, coherence, displacement, and entanglement links across the body.",
+  },
+};
+
+const INSPECT_REGION_COPY: Record<BodyRegion, ModeCopy> = {
+  head: {
+    eyebrow: "Local Observation",
+    title: "The Signal of Thought",
+    metaphor:
+      "The head behaves like a small observatory. A touch here feels like asking the body where attention begins before it becomes a visible decision.",
+    science:
+      "This region maps the selected head node to a qubit sample. The returned bit, probability, and coherence values describe the local simulated state without triggering a full-body collapse. It shows strong entanglement with adjacent regions such as the torso, where local observation can influence nearby body states.",
+  },
+  torso: {
+    eyebrow: "Local Observation",
+    title: "The Chamber of Resonance",
+    metaphor:
+      "The torso holds the body like a resonant chamber. When it is inspected, the field answers from the center, where separate signals begin to feel connected.",
+    science:
+      "Torso inspection samples the qubit associated with the body's central region. Its probability and coherence are used to visualize how stable the local state remains under observation. It shows strong entanglement with adjacent regions including the head, arms, and legs, acting as the main bridge between local states.",
+  },
+  leftArm: {
+    eyebrow: "Local Observation",
+    title: "The Left Arc of Contact",
+    metaphor:
+      "The left arm is a line reaching outward. Inspecting it turns gesture into evidence, as if touch could leave a measurable trace in the field.",
+    science:
+      "Left arm inspection maps the selected arm node to a qubit index and reads a localized measurement result. The UI shows whether the node remains superposed or has collapsed in the sampled state. It shows strong entanglement with adjacent regions such as the torso and shoulder-side nodes.",
+  },
+  rightArm: {
+    eyebrow: "Local Observation",
+    title: "The Right Arc of Action",
+    metaphor:
+      "The right arm carries intention into space. A measurement here feels like watching possibility become an action before the whole body follows.",
+    science:
+      "Right arm inspection performs the same localized node measurement for the right-side region. The sampled bit and coherence value are used to represent local quantum response. It shows strong entanglement with adjacent regions such as the torso and shoulder-side nodes.",
+  },
+  leftLeg: {
+    eyebrow: "Local Observation",
+    title: "The Left Anchor of Balance",
+    metaphor:
+      "The left leg is an anchor beneath uncertainty. Inspecting it asks how a body keeps balance while its state is still unfinished.",
+    science:
+      "Left leg inspection samples the mapped lower-body qubit. The resulting probability and coherence values indicate how the local simulated state contributes to body stability. It shows strong entanglement with adjacent regions such as the torso and neighboring lower-body nodes.",
+  },
+  rightLeg: {
+    eyebrow: "Local Observation",
+    title: "The Right Anchor of Motion",
+    metaphor:
+      "The right leg suggests the beginning of movement. A touch here reads the body at the edge between stillness and departure.",
+    science:
+      "Right leg inspection reads the corresponding lower-body qubit sample. Its measured bit, probability, and coherence are displayed as the local state of that region. It shows strong entanglement with adjacent regions such as the torso and neighboring lower-body nodes.",
+  },
+};
+
+const INSPECT_NODE_COPY: Record<number, ModeCopy> = {
+  0: {
+    eyebrow: "Local Observation",
+    title: "Head: The Observing Field",
+    metaphor: "The helmet becomes a quiet observatory, where attention gathers before the body chooses how to answer.",
+    science:
+      "The head node is mapped to the upper-body qubit sample. It is strongly entangled with adjacent nodes such as Chest and Oxygen Tank, so a local observation here can shift the nearby central network.",
+  },
+  1: {
+    eyebrow: "Local Observation",
+    title: "Chest: The Resonant Core",
+    metaphor: "The chest receives signals like breath inside a chamber, turning separate points into one shared pulse.",
+    science:
+      "The chest node sits at the central bridge of the network. It shows strong entanglement with Head, Torso, Oxygen Tank, and both shoulder nodes, making it one of the most connected local states.",
+  },
+  2: {
+    eyebrow: "Local Observation",
+    title: "Torso: The Body's Axis",
+    metaphor: "The torso holds the body's vertical axis, where upper motion and lower balance meet inside one field.",
+    science:
+      "The torso node connects the upper body to both legs. It is strongly entangled with Chest, Oxygen Tank, Right Leg, and Left Leg, so its measurement describes how the body transfers state between regions.",
+  },
+  3: {
+    eyebrow: "Local Observation",
+    title: "Oxygen Tank: The Hidden Reservoir",
+    metaphor: "The oxygen tank is the unseen reserve behind the body, a quiet source that keeps the field alive.",
+    science:
+      "The oxygen tank node is treated as a back-side support state. It is strongly entangled with Head, Chest, Torso, and both shoulder nodes, linking visible posture to hidden structural context.",
+  },
+  4: {
+    eyebrow: "Local Observation",
+    title: "Right Shoulder: The Joint of Intention",
+    metaphor: "The right shoulder is a hinge between center and reach, where intention prepares to leave the torso.",
+    science:
+      "The right shoulder node is strongly entangled with Chest, Oxygen Tank, and Right Arm. Its local measurement helps explain how the central state propagates into the right-side limb.",
+  },
+  5: {
+    eyebrow: "Local Observation",
+    title: "Left Shoulder: The Joint of Contact",
+    metaphor: "The left shoulder opens a path from the body's center toward contact with the surrounding field.",
+    science:
+      "The left shoulder node is strongly entangled with Chest, Oxygen Tank, and Left Arm. Its sampled state represents the transfer between the torso network and the left-side limb.",
+  },
+  6: {
+    eyebrow: "Local Observation",
+    title: "Right Arm: The Arc of Action",
+    metaphor: "The right arm extends possibility outward, turning the body's inner signal into visible action.",
+    science:
+      "The right arm node is strongly entangled with Right Shoulder and Right Hand. Measurement here reads a mid-limb state between central intention and endpoint response.",
+  },
+  7: {
+    eyebrow: "Local Observation",
+    title: "Left Arm: The Arc of Contact",
+    metaphor: "The left arm reaches like a drawn line, carrying the body's relation into space.",
+    science:
+      "The left arm node is strongly entangled with Left Shoulder and Left Hand. Its local sample shows how a nearby shoulder state continues toward the hand.",
+  },
+  8: {
+    eyebrow: "Local Observation",
+    title: "Right Hand: The Point of Touch",
+    metaphor: "The right hand is where the body becomes an instrument, leaving a precise trace in the field.",
+    science:
+      "The right hand node is strongly entangled with Right Arm. As an endpoint node, its measurement emphasizes how a local touch reflects the state carried through the adjacent limb.",
+  },
+  9: {
+    eyebrow: "Local Observation",
+    title: "Left Hand: The Point of Response",
+    metaphor: "The left hand catches the field at its edge, where relation becomes a visible response.",
+    science:
+      "The left hand node is strongly entangled with Left Arm. Its sampled bit and coherence describe the endpoint response of the left-side connection chain.",
+  },
+  10: {
+    eyebrow: "Local Observation",
+    title: "Right Leg: The Descent of Motion",
+    metaphor: "The right leg carries the body's uncertainty downward, preparing stillness to become movement.",
+    science:
+      "The right leg node is strongly entangled with Torso and Right Foot. It represents how the central body state is transferred into lower-body motion and support.",
+  },
+  11: {
+    eyebrow: "Local Observation",
+    title: "Left Leg: The Descent of Balance",
+    metaphor: "The left leg steadies the field, giving the body's possible states a place to stand.",
+    science:
+      "The left leg node is strongly entangled with Torso and Left Foot. Its measurement explains how lower-body balance remains coupled to the central torso state.",
+  },
+  12: {
+    eyebrow: "Local Observation",
+    title: "Right Foot: The Grounded Trace",
+    metaphor: "The right foot marks the boundary between body and ground, where motion leaves its final trace.",
+    science:
+      "The right foot node is strongly entangled with Right Leg. As a lower endpoint, it shows how the adjacent leg state resolves into support and contact.",
+  },
+  13: {
+    eyebrow: "Local Observation",
+    title: "Left Foot: The Grounded Echo",
+    metaphor: "The left foot answers the body from below, turning balance into a quiet echo of the whole network.",
+    science:
+      "The left foot node is strongly entangled with Left Leg. Its local measurement reflects the endpoint of the left lower-body entanglement chain.",
+  },
+};
+
 type InspectedNode = {
   index: number;
   qubitIndex: number;
@@ -137,6 +307,10 @@ export function QuantumNodeDashboard({
   const inspectedNodeState = getInspectedNodeState(nodeStates, inspectedNode);
   const sceneProgress = mode === "collapse" ? collapseProgress : stableProgress;
   const sceneStatus = loading ? "measuring" : modelStable ? "stabilizing" : "ready";
+  const copy =
+    appMode === "inspect"
+      ? INSPECT_NODE_COPY[inspectedNode?.index ?? -1] ?? INSPECT_REGION_COPY[inspectedNode?.region ?? "torso"]
+      : MODE_COPY.measurement;
 
   if (appMode === "inspect" && !inspectedNode) return null;
 
@@ -144,25 +318,29 @@ export function QuantumNodeDashboard({
     <aside className={`quantum-dashboard quantum-dashboard--${appMode}`} aria-label="Quantum node dashboard">
       <header className="quantum-dashboard__header">
         <div>
-          <div className="quantum-dashboard__eyebrow">{appMode === "inspect" ? "Quantum Node" : "Entangled State"}</div>
-          <h2>{appMode === "inspect" ? "Node Inspector" : "Collapse Monitor"}</h2>
+          <div className="quantum-dashboard__eyebrow">{copy.eyebrow}</div>
+          <h2>{copy.title}</h2>
         </div>
         <StatusPill status={status} />
       </header>
 
-      <section className="quantum-dashboard__scene-status" aria-label="Scene quantum status">
-        <div className="quantum-dashboard__scene-status-header">
-          <span>{mode}</span>
-          <strong>{sceneStatus}</strong>
-        </div>
-        <div className="quantum-dashboard__progress">
-          <i style={{ width: `${Math.round(sceneProgress * 100)}%` }} />
-        </div>
-        <div className="quantum-dashboard__scene-status-footer">
-          <span>{mode === "collapse" ? "collapse" : "stability"}</span>
-          <b>{Math.round(sceneProgress * 100)}%</b>
-        </div>
-      </section>
+      {appMode === "measurement" ? (
+        <section className="quantum-dashboard__scene-status" aria-label="Scene quantum status">
+          <div className="quantum-dashboard__scene-status-header">
+            <span>{mode}</span>
+            <strong>{sceneStatus}</strong>
+          </div>
+          <div className="quantum-dashboard__progress">
+            <i style={{ width: `${Math.round(sceneProgress * 100)}%` }} />
+          </div>
+          <div className="quantum-dashboard__scene-status-footer">
+            <span>{mode === "collapse" ? "collapse" : "stability"}</span>
+            <b>{Math.round(sceneProgress * 100)}%</b>
+          </div>
+        </section>
+      ) : null}
+
+      <ModeStory copy={copy} />
 
       {appMode === "measurement" ? (
         <MeasurementState measurement={effectiveMeasurement} />
@@ -174,7 +352,6 @@ export function QuantumNodeDashboard({
               <Metric label="Node" value={formatNodeLabel(inspectedNode?.index)} />
               <Metric label="Qubit" value={String(inspectedNode?.qubitIndex ?? "--")} />
               <Metric label="Bit" value={inspectedNodeState?.measuredBit ?? "-"} />
-              <Metric label="State" value={inspectedNodeState?.collapsed ? "Collapsed" : "Superposed"} />
               <Metric label="Probability" value={formatStateValue(inspectedNodeState?.probability)} />
               <Metric label="Coherence" value={formatStateValue(inspectedNodeState?.coherence)} />
             </div>
@@ -239,12 +416,24 @@ export function QuantumNodeDashboard({
             <Metric label="Links" value={String(effectiveMeasurement?.entanglementLinks?.length ?? 0)} />
           </section>
 
-          <NodeStateList nodeStates={nodeStates} />
+          <NodeStateList nodeStates={nodeStates} showState={false} />
         </>
       )}
 
       {effectiveMeasurement?.fallbackReason ? <div className="quantum-dashboard__warning">Fallback: {effectiveMeasurement.fallbackReason}</div> : null}
     </aside>
+  );
+}
+
+function ModeStory({ copy }: { copy: ModeCopy }) {
+  return (
+    <section className="quantum-dashboard__story" aria-label="Mode story and scientific information">
+      <p>{copy.metaphor}</p>
+      <div className="quantum-dashboard__science">
+        <div className="quantum-dashboard__section-title">Scientific Information</div>
+        <p>{copy.science}</p>
+      </div>
+    </section>
   );
 }
 
@@ -327,16 +516,16 @@ function clampInteger(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Math.round(value)));
 }
 
-function NodeStateList({ nodeStates }: { nodeStates: QuantumNodeState[] }) {
+function NodeStateList({ nodeStates, showState = true }: { nodeStates: QuantumNodeState[]; showState?: boolean }) {
   return (
     <section className="quantum-dashboard__nodes">
       <div className="quantum-dashboard__section-title">Node States</div>
       {nodeStates.length > 0 ? (
         nodeStates.map((node) => (
-          <div key={`${node.region}-${node.qubitIndex}`} className="quantum-dashboard__node-row">
+          <div key={`${node.region}-${node.qubitIndex}`} className={showState ? "quantum-dashboard__node-row" : "quantum-dashboard__node-row quantum-dashboard__node-row--compact"}>
             <span>{REGION_LABELS[node.region]}</span>
             <b>{node.measuredBit}</b>
-            <i>{node.collapsed ? "collapsed" : "superposed"}</i>
+            {showState ? <i>{node.collapsed ? "collapsed" : "measured"}</i> : null}
           </div>
         ))
       ) : (

--- a/apps/web/components/SpaceEnvironment.tsx
+++ b/apps/web/components/SpaceEnvironment.tsx
@@ -39,11 +39,16 @@ type EarthTextures = {
   glow: Texture;
 };
 
-export function SpaceEnvironment() {
+type SpaceEnvironmentProps = {
+  sunOcclusion?: number;
+};
+
+export function SpaceEnvironment({ sunOcclusion = 0 }: SpaceEnvironmentProps) {
   const [moon, setMoon] = useState<LoadedMoon | null>(null);
   const [sunTextures, setSunTextures] = useState<SunTextures | null>(null);
   const [earthTextures, setEarthTextures] = useState<EarthTextures | null>(null);
-  const sunLensflare = useMemo(() => (sunTextures ? createSunLensflare(sunTextures) : null), [sunTextures]);
+  const flareVisibility = 1 - Math.max(0, Math.min(1, sunOcclusion));
+  const sunLensflare = useMemo(() => (sunTextures ? createSunLensflare(sunTextures, flareVisibility) : null), [sunTextures, flareVisibility]);
 
   const starPositions = useMemo(() => {
     const starCount = 9000;
@@ -232,11 +237,11 @@ export function SpaceEnvironment() {
       </points>
 
       {earthTextures ? (
-        <group position={[18, 3.8, -40]}>
-          <sprite scale={[5.8, 5.8, 1]}>
+        <group position={[9.4, -13.2, -42]}>
+          <sprite scale={[17.4, 17.4, 1]}>
             <spriteMaterial map={earthTextures.glow} color="#78c9ff" transparent opacity={0.65} blending={AdditiveBlending} depthWrite={false} toneMapped={false} />
           </sprite>
-          <sprite scale={[4.7, 4.7, 1]}>
+          <sprite scale={[14.1, 14.1, 1]}>
             <spriteMaterial map={earthTextures.disc} transparent depthWrite={false} toneMapped={false} />
           </sprite>
         </group>
@@ -353,12 +358,11 @@ function createEarthGlowTexture() {
   return finalizeCanvasTexture(canvas);
 }
 
-function createSunLensflare(textures: SunTextures) {
+function createSunLensflare(textures: SunTextures, opacity: number) {
   const flare = new Lensflare();
-  flare.addElement(new LensflareElement(textures.flare, 760, 0, new Color("#fff7d6")));
-  flare.addElement(new LensflareElement(textures.flare, 160, 0.38, new Color("#ffd06a")));
-  flare.addElement(new LensflareElement(textures.flare, 92, 0.63, new Color("#ff8f45")));
-  flare.addElement(new LensflareElement(textures.flare, 52, 0.86, new Color("#fff0a0")));
+  flare.addElement(new LensflareElement(textures.flare, 160, 0.38, new Color("#ffd06a").multiplyScalar(opacity)));
+  flare.addElement(new LensflareElement(textures.flare, 92, 0.63, new Color("#ff8f45").multiplyScalar(opacity)));
+  flare.addElement(new LensflareElement(textures.flare, 52, 0.86, new Color("#fff0a0").multiplyScalar(opacity)));
   return flare;
 }
 


### PR DESCRIPTION
## Summary
  - Added an artistic loading intro with starfield
  background, typewriter text, typing sound, fade-
  out transition, and local background music
  playback.
  - Updated the 3D scene composition with Earth
  placement, sun/lens flare behavior, and collapse
  visual timing.
  - Refined Inspect and Measurement modes with
  clearer entanglement-focused behavior and
  dashboard storytelling.
  - Added node-specific Inspect mode descriptions
  with scientific information tied to adjacent
  entanglement relationships.
  - Updated Measurement mode so clicking triggers
  full collapse, disconnects/fades blue nodes,
  then gradually returns to the original state.

  ## Related Issue
  Closes #

  ## Type
  - [x] Feature
  - [x] Bug fix
  - [ ] Refactor
  - [x] Docs
  - [ ] Chore

  ## Checklist
  - [x] `npm run typecheck` passes
  - [ ] `npm run build` passes
  - [x] Tested locally
  - [ ] Verified in preview deployment
  - [x] No secrets exposed
  - [x] Docs updated if needed

  ## Screenshots / Video
  <!-- Add if visual change -->

  ## Notes for Reviewer
  - Please focus on the loading intro flow,
  Measurement mode collapse/return timing, and
  whether the dashboard copy accurately supports
  the entanglement theme.
  - Sun/lens flare behavior was adjusted so the
  sun remains stable while only the flare
  artifacts fade during collapse.