### PR TITLE
Implement hover mesh masking and quantumNodeDashboard toggling

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -225,6 +225,37 @@ button {
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.36);
   backdrop-filter: blur(16px);
   color: #f5f7fb;
+  visibility: visible;
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  transform-origin: top right;
+  transition:
+    opacity 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 0ms linear 0ms;
+  will-change: opacity, transform;
+}
+
+.quantum-dashboard--visible {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
+  transition:
+    opacity 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 0ms linear 0ms;
+}
+
+.quantum-dashboard--hidden {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(34px, 0, 0);
+  transition:
+    opacity 240ms cubic-bezier(0.4, 0, 1, 1),
+    transform 240ms cubic-bezier(0.4, 0, 1, 1),
+    visibility 0ms linear 240ms;
 }
 
 .quantum-dashboard__header,
@@ -660,6 +691,11 @@ button {
     bottom: 16px;
     width: auto;
     max-height: 48vh;
+    transform-origin: bottom center;
+  }
+
+  .quantum-dashboard--hidden {
+    transform: translate3d(0, 28px, 0);
   }
 
   .quantum-node-overlay {

--- a/apps/web/components/BodyScene.tsx
+++ b/apps/web/components/BodyScene.tsx
@@ -28,6 +28,7 @@ type InspectedNode = {
 export function BodyScene() {
   const [mode, setMode] = useState<"superposition" | "collapse">("superposition");
   const [appMode, setAppMode] = useState<AppMode>("inspect");
+  const [measurementDashboardVisible, setMeasurementDashboardVisible] = useState(false);
   const [collapseProgress, setCollapseProgress] = useState(0);
   const [quantumState, setQuantumState] = useState<BodyQuantumState>({
     regionStates: emptyRegionStates(),
@@ -253,6 +254,15 @@ export function BodyScene() {
   }, []);
 
   const switchAppMode = useCallback((nextMode: AppMode) => {
+    if (nextMode === "measurement") {
+      if (appMode === "measurement") {
+        setMeasurementDashboardVisible((visible) => !visible);
+        return;
+      }
+
+      setMeasurementDashboardVisible(true);
+    }
+
     setAppMode(nextMode);
     setError(null);
     setInspectedNode(null);
@@ -269,7 +279,7 @@ export function BodyScene() {
       setConnectionBreakPoint(null);
       setConnectionBreakProgress(0);
     }
-  }, []);
+  }, [appMode]);
 
   return (
     <main style={{ width: "100vw", height: "100vh", position: "relative" }}>
@@ -314,6 +324,7 @@ export function BodyScene() {
       <QuantumNodeDashboard
         latestMeasurement={latestMeasurement}
         appMode={appMode}
+        visible={appMode !== "measurement" || measurementDashboardVisible}
         mode={mode}
         collapseProgress={collapseProgress}
         stableProgress={stableProgress}

--- a/apps/web/components/OriginalGlbModel.tsx
+++ b/apps/web/components/OriginalGlbModel.tsx
@@ -3,7 +3,7 @@
 import type { ThreeEvent } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AdditiveBlending, Box3, BufferGeometry, Float32BufferAttribute, Material, Mesh, NormalBlending, Object3D, SkinnedMesh, Vector3, type Vector3Tuple } from "three";
+import { AdditiveBlending, Box3, BufferGeometry, Float32BufferAttribute, Material, Mesh, NormalBlending, Object3D, PointsMaterial, SkinnedMesh, Vector3, type Vector3Tuple } from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { MeshSurfaceSampler } from "three/examples/jsm/math/MeshSurfaceSampler.js";
 
@@ -63,6 +63,12 @@ type WaveMaterialBinding = {
 type WaveMaterial = Material & {
   userData: {
     entangledUniforms?: Record<string, { value: number | Vector3 }>;
+  };
+};
+
+type MaskedPointMaterial = PointsMaterial & {
+  userData: {
+    hoverMaskUniforms?: Record<string, { value: number | Vector3 }>;
   };
 };
 
@@ -136,6 +142,14 @@ export function OriginalGlbModel({
 }: OriginalGlbModelProps) {
   const [model, setModel] = useState<LoadedModel | null>(null);
   const holdTimer = useRef<number | null>(null);
+  const surfaceGlowMaterial = useMemo(
+    () => prepareMaskedPointMaterial({ size: 0.042, opacity: 0.05, blending: AdditiveBlending }),
+    [],
+  );
+  const surfacePointMaterial = useMemo(
+    () => prepareMaskedPointMaterial({ size: 0.015, opacity: 0.68 }),
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -201,6 +215,13 @@ export function OriginalGlbModel({
     };
   }, [model]);
 
+  useEffect(() => {
+    return () => {
+      surfaceGlowMaterial.dispose();
+      surfacePointMaterial.dispose();
+    };
+  }, [surfaceGlowMaterial, surfacePointMaterial]);
+
   useFrame(({ clock }) => {
     if (!model) return;
 
@@ -214,6 +235,8 @@ export function OriginalGlbModel({
     const surfaceInteractionPoint = stable && stablePoint ? stablePoint : hoveredPoint;
 
     updateSurfaceGlowPointColors(model.surfaceGlowPointGeometry, model.scene, surfaceInteractionPoint);
+    updateMaskedPointMaterial(surfaceGlowMaterial, surfaceInteractionPoint, model.scene, surfaceGlowOpacityForFrame(stable, stableProgress, hoveredPoint, stablePoint));
+    updateMaskedPointMaterial(surfacePointMaterial, surfaceInteractionPoint, model.scene, surfacePointOpacityForFrame(stable, stableProgress, hoveredPoint, stablePoint));
     for (const binding of model.bindings) {
       const material = binding.material;
       material.opacity = effectiveOpacity;
@@ -237,7 +260,7 @@ export function OriginalGlbModel({
       uniforms.uHoveredRegion.value = regionToId(hoveredRegion);
       uniforms.uHasHoverPoint.value = hasHoverPoint;
       uniforms.uHoverPoint.value = localHover;
-      uniforms.uHoverRadius.value = 0.92;
+      uniforms.uHoverRadius.value = 1.0;
       uniforms.uHasStablePoint.value = hasStablePoint;
       uniforms.uStablePoint.value = localStable;
       uniforms.uStableProgress.value = stableProgress;
@@ -249,9 +272,6 @@ export function OriginalGlbModel({
   if (!model) return null;
 
   const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
-  const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
-  const surfaceGlowOpacity = (hasSurfaceInteraction ? 0.34 : 0.05) * surfaceFade;
-  const surfacePointOpacity = (hasSurfaceInteraction ? 0.34 : 0.68) * surfaceFade;
   const activeFixedPointSource = connectionBreakPoint ?? (stable && stablePoint ? stablePoint : hoveredPoint);
   const showFullEntanglement = Boolean(hoveredPoint || connectionBreakPoint || stablePoint);
   const disconnectEntanglement = Boolean(connectionBreakPoint);
@@ -278,10 +298,10 @@ export function OriginalGlbModel({
       {surfaceFade > 0.001 ? (
         <>
           <points geometry={model.surfaceGlowPointGeometry} frustumCulled={false} renderOrder={3} raycast={ignorePointRaycast}>
-            <pointsMaterial size={0.042} sizeAttenuation vertexColors transparent opacity={surfaceGlowOpacity} blending={AdditiveBlending} depthTest depthWrite={false} />
+            <primitive object={surfaceGlowMaterial} attach="material" />
           </points>
           <points geometry={model.surfacePointGeometry} frustumCulled={false} renderOrder={4} raycast={ignorePointRaycast}>
-            <pointsMaterial size={0.015} sizeAttenuation vertexColors transparent opacity={surfacePointOpacity} depthTest depthWrite={false} />
+            <primitive object={surfacePointMaterial} attach="material" />
           </points>
         </>
       ) : null}
@@ -1000,6 +1020,100 @@ function isSkinnedMesh(mesh: Mesh): mesh is SkinnedMesh {
 }
 
 function ignorePointRaycast(): void {}
+
+function surfaceGlowOpacityForFrame(stable: boolean, stableProgress: number, hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
+  const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
+  const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
+  return (hasSurfaceInteraction ? 0.34 : 0.05) * surfaceFade;
+}
+
+function surfacePointOpacityForFrame(stable: boolean, stableProgress: number, hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
+  const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
+  const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
+  return (hasSurfaceInteraction ? 0.34 : 0.68) * surfaceFade;
+}
+
+function prepareMaskedPointMaterial({
+  size,
+  opacity,
+  blending = NormalBlending,
+}: {
+  size: number;
+  opacity: number;
+  blending?: typeof AdditiveBlending | typeof NormalBlending;
+}): MaskedPointMaterial {
+  const material = new PointsMaterial({
+    size,
+    sizeAttenuation: true,
+    vertexColors: true,
+    transparent: true,
+    opacity,
+    blending,
+    depthTest: true,
+    depthWrite: false,
+  }) as MaskedPointMaterial;
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uHasHiddenPoint = { value: 0 };
+    shader.uniforms.uHiddenPoint = { value: new Vector3() };
+    shader.uniforms.uHiddenRadius = { value: HOVER_COLOR_RADIUS * 0.92 };
+    material.userData.hoverMaskUniforms = shader.uniforms;
+
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        "void main() {",
+        `
+uniform float uHasHiddenPoint;
+uniform vec3 uHiddenPoint;
+uniform float uHiddenRadius;
+varying float vPointCloudVisibility;
+
+void main() {`,
+      )
+      .replace(
+        "#include <begin_vertex>",
+        `#include <begin_vertex>
+  float hiddenInfluence = uHasHiddenPoint * (1.0 - smoothstep(uHiddenRadius * 0.55, uHiddenRadius, distance(transformed, uHiddenPoint)));
+  vPointCloudVisibility = 1.0 - hiddenInfluence;`,
+      );
+
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        "void main() {",
+        `
+varying float vPointCloudVisibility;
+
+void main() {`,
+      )
+      .replace(
+        "#include <clipping_planes_fragment>",
+        `#include <clipping_planes_fragment>
+if (vPointCloudVisibility <= 0.02) discard;`,
+      )
+      .replace(
+        "#include <opaque_fragment>",
+        `diffuseColor.a *= smoothstep(0.0, 1.0, vPointCloudVisibility);
+#include <opaque_fragment>`,
+      );
+  };
+
+  material.needsUpdate = true;
+  return material;
+}
+
+function updateMaskedPointMaterial(material: MaskedPointMaterial, interactionPoint: Vector3Tuple | null, scene: Object3D, opacity: number): void {
+  material.opacity = opacity;
+
+  const uniforms = material.userData.hoverMaskUniforms;
+  if (!uniforms) return;
+
+  uniforms.uHasHiddenPoint.value = interactionPoint ? 1 : 0;
+  if (interactionPoint) {
+    reusableSurfaceInteraction.fromArray(interactionPoint);
+    scene.worldToLocal(reusableSurfaceInteraction);
+    uniforms.uHiddenPoint.value = reusableSurfaceInteraction;
+  }
+}
 
 function prepareMaterial(source: Material, opacity: number): WaveMaterial {
   const material = source.clone() as WaveMaterial;

--- a/apps/web/components/QuantumNodeDashboard.tsx
+++ b/apps/web/components/QuantumNodeDashboard.tsx
@@ -218,6 +218,7 @@ type InspectedNode = {
 type QuantumNodeDashboardProps = {
   latestMeasurement?: QuantumMeasurementPayload | null;
   appMode: "inspect" | "measurement";
+  visible: boolean;
   mode: "superposition" | "collapse";
   collapseProgress: number;
   stableProgress: number;
@@ -229,6 +230,7 @@ type QuantumNodeDashboardProps = {
 export function QuantumNodeDashboard({
   latestMeasurement = null,
   appMode,
+  visible,
   mode,
   collapseProgress,
   stableProgress,
@@ -246,6 +248,10 @@ export function QuantumNodeDashboard({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastChecked, setLastChecked] = useState<string>("--");
+  const hasInspectedNode = inspectedNode !== null;
+  const targetVisible = visible && (appMode !== "inspect" || hasInspectedNode);
+  const [renderDashboard, setRenderDashboard] = useState(targetVisible);
+  const [animateDashboard, setAnimateDashboard] = useState(targetVisible);
 
   const refreshHealth = useCallback(async () => {
     try {
@@ -266,6 +272,24 @@ export function QuantumNodeDashboard({
   useEffect(() => {
     void refreshHealth();
   }, [refreshHealth]);
+
+  useEffect(() => {
+    if (targetVisible) {
+      setRenderDashboard(true);
+      let secondFrame = 0;
+      const firstFrame = window.requestAnimationFrame(() => {
+        secondFrame = window.requestAnimationFrame(() => setAnimateDashboard(true));
+      });
+      return () => {
+        window.cancelAnimationFrame(firstFrame);
+        window.cancelAnimationFrame(secondFrame);
+      };
+    }
+
+    setAnimateDashboard(false);
+    const timeout = window.setTimeout(() => setRenderDashboard(false), 340);
+    return () => window.clearTimeout(timeout);
+  }, [targetVisible]);
 
   useEffect(() => {
     if (latestMeasurement) {
@@ -312,10 +336,16 @@ export function QuantumNodeDashboard({
       ? INSPECT_NODE_COPY[inspectedNode?.index ?? -1] ?? INSPECT_REGION_COPY[inspectedNode?.region ?? "torso"]
       : MODE_COPY.measurement;
 
-  if (appMode === "inspect" && !inspectedNode) return null;
+  if (!renderDashboard) return null;
 
   return (
-    <aside className={`quantum-dashboard quantum-dashboard--${appMode}`} aria-label="Quantum node dashboard">
+    <aside
+      className={`quantum-dashboard quantum-dashboard--${appMode} ${
+        animateDashboard ? "quantum-dashboard--visible" : "quantum-dashboard--hidden"
+      }`}
+      aria-hidden={!animateDashboard}
+      aria-label="Quantum node dashboard"
+    >
       <header className="quantum-dashboard__header">
         <div>
           <div className="quantum-dashboard__eyebrow">{copy.eyebrow}</div>


### PR DESCRIPTION
## Summary
- used alpha mask to show only GLB mesh on hover, hide point cloud
- implemented toggling of quantumNodeDashboard

## Related Issue
#31 

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Checklist
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally
- [ ] Verified in preview deployment
- [ ] No secrets exposed
- [ ] Docs updated if needed