### PR TITLE
Document AWS deployment workflow and Terraform runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,31 @@ Entangled Body is a separated frontend/backend prototype for rendering a GLB bod
 - `apps/api/data/precomputed_samples.json`: weak measurement samples used by hover interactions.
 - `apps/web/public/models/astronaut_rigged_and_animated.glb`: source model sampled into render tiles.
 
-## AWS Deployment Architecture
+## Live Demo
 
-The README architecture is written around the **initial deployment target**. The expanded ECS architecture is documented as a later scaling path, not as the first version to run continuously. This keeps the project cost-aware while still leaving room for deeper AWS deployment work after the creative quantum experience is stable.
+```text
+https://entangledbody.com
+```
 
-### Initial Deployment Target
+API health check:
 
-The first AWS deployment uses S3 and CloudFront for the frontend, plus one managed container service for the FastAPI quantum backend. This is the recommended starting point for the challenge-ready live version because it is inexpensive, understandable, and keeps the focus on the quantum creative interaction.
+```text
+https://entangledbody.com/api/health
+```
+
+## Deployment
+
+The live demo is deployed on AWS with a small production-style setup: S3 and CloudFront serve the static frontend, CloudFront forwards `/api/*` requests to the FastAPI backend on App Runner, and Route 53/ACM provide the custom HTTPS domain.
 
 ```mermaid
 flowchart LR
-    user[User / qoollab domain]
+    user[User / entangledbody.com]
     dns[Route 53]
     cert[ACM HTTPS certificate]
     cf[CloudFront CDN]
     s3web[S3 static frontend]
-    api[App Runner or ECS Fargate<br/>FastAPI + Qiskit]
+    ecr[ECR API image]
+    api[App Runner<br/>FastAPI + Qiskit]
     logs[CloudWatch Logs]
 
     user --> dns
@@ -32,109 +41,13 @@ flowchart LR
     cert --> cf
     cf --> s3web
     cf -->|/api/*| api
+    ecr --> api
     api --> logs
 ```
 
-- Host the Next.js static frontend in S3 and serve it through CloudFront.
-- Restrict the S3 origin with CloudFront Origin Access Control, so users cannot bypass CloudFront and read the bucket directly.
-- Use Route 53 and ACM for the custom HTTPS domain.
-- Deploy the FastAPI backend from the existing Docker image.
-- Prefer App Runner for the first backend deployment if simplicity and cost control matter more than showing ECS internals.
-- Use a single ECS Fargate service as the alternative if the deployment needs to demonstrate ECS directly.
-- Use CloudWatch Logs with a short retention period.
-- Add an AWS Budget or billing alarm before leaving the service running.
-
-### Deployment Flow
-
-```mermaid
-flowchart LR
-    dev[Developer push]
-    gha[GitHub Actions]
-    webbuild[Build static frontend]
-    s3deploy[Upload to S3]
-    invalidate[Invalidate CloudFront cache]
-    image[Build API image]
-    backend[Deploy App Runner or ECS service]
-
-    dev --> gha
-    gha --> webbuild --> s3deploy --> invalidate
-    gha --> image --> backend
-```
-
-- Frontend CI builds the static site, syncs the output to S3, and invalidates CloudFront.
-- Backend CI builds the FastAPI container and deploys it to App Runner or ECS.
-- Environment-specific values such as API base URL, AWS account ID, and service names should be stored as GitHub Actions secrets or environment variables.
-- If S3 static hosting is used, the Next.js app must remain compatible with static export constraints.
-
-### Expansion Target
-
-After the first deployment is stable, the architecture can be expanded if Entangled Body needs more control over backend routing, container operations, observability, or infrastructure automation:
-
-```mermaid
-flowchart LR
-    user[User / qoollab domain]
-    r53[Route 53 + ACM]
-    cf[CloudFront]
-    s3web[S3 static frontend]
-    alb[Application Load Balancer]
-    ecs[ECS Fargate service<br/>FastAPI + Qiskit]
-    ecr[ECR container registry]
-    s3data[S3 precomputed quantum data]
-    gha[GitHub Actions CI/CD]
-    cw[CloudWatch Logs + Alarms]
-    iac[Terraform or CDK]
-
-    user --> r53 --> cf
-    cf --> s3web
-    cf -->|/api/*| alb --> ecs
-    gha --> ecr --> ecs
-    ecs --> s3data
-    ecs --> cw
-    iac -.provisions.-> r53
-    iac -.provisions.-> cf
-    iac -.provisions.-> s3web
-    iac -.provisions.-> alb
-    iac -.provisions.-> ecs
-    iac -.provisions.-> ecr
-    iac -.provisions.-> cw
-```
-
-This version gives more operational control, but it is not the recommended always-on first deployment because ALB, ECS, networking, and observability resources increase cost and operational surface area.
-
-### Cost Controls
-
-- Avoid a NAT Gateway for the first ECS version by running the Fargate task in a public subnet with a public IP.
-- Keep the Fargate desired task count at `1` for a challenge/demo deployment.
-- Use small CPU and memory values first, then tune only if Qiskit workloads need more.
-- Consider App Runner instead of ALB + ECS when the project does not need VPC-level control.
-- Keep CloudWatch log retention short, such as 3-7 days.
-- Use AWS Budgets or billing alarms before enabling always-on resources.
-- Tear down or scale down ALB/ECS resources when they are only needed for a demo.
-
-### Monitoring
-
-- Use `/health` and `/quantum/health` as backend health check endpoints.
-- Send backend container logs to CloudWatch Logs.
-- Add alarms for service errors, unhealthy backend responses, and unexpected monthly spend.
-- Start with minimal metrics and alarms, then expand once the service is receiving real traffic.
-
-### Tradeoffs
-
-- **Why S3 + CloudFront instead of Amplify Hosting:** the main goal is to present Entangled Body as a fast, reliable web-based quantum creative experience. S3 and CloudFront keep the visual frontend lightweight, cacheable, and easy to serve globally while still leaving the deployment path transparent.
-- **Why App Runner first:** the backend exists to support the interaction between the browser, FastAPI, Qiskit, and future IonQ execution. App Runner keeps the first live version focused on the creative quantum experience instead of early networking complexity.
-- **Why ECS Fargate later:** ECS Fargate is an expansion path if the project needs more control over container runtime, routing, observability, or infrastructure-as-code. It is not required for the first challenge-ready version.
-- **Why no NAT Gateway in the small ECS version:** if ECS is used for a demo deployment, avoiding a NAT Gateway keeps fixed cloud cost low. The infrastructure should support the artwork and quantum interaction, not become the center of the project.
 - **Why precomputed quantum data exists:** precomputed samples keep hover interactions fast and predictable, reduce backend compute load, and preserve the interactive rhythm of the piece while live quantum or simulator calls remain available for stronger measurement events.
 
-### Infrastructure Roadmap
-
-1. Document the target architecture and cost controls in this README.
-2. Make the frontend compatible with S3 static deployment.
-3. Deploy the frontend to S3 behind CloudFront with OAC.
-4. Deploy the FastAPI backend to App Runner or one small ECS Fargate service.
-5. Add GitHub Actions for frontend and backend deployment.
-6. Add Route 53, ACM, CloudWatch logs, and budget alarms.
-7. Expand to ALB + ECS Fargate + ECR + Terraform/CDK only if the project needs more operational control or a stronger AWS implementation story.
+Detailed Terraform variables, manual deployment commands, custom domain notes, redeployment steps, and planned CI/CD improvements live in [infra/terraform/README.md](infra/terraform/README.md).
 
 ## Run the Frontend
 
@@ -189,12 +102,6 @@ The backend simulator returns counts and the dominant bitstring. `quantum/mapper
 - `displacement`: a signed visual offset for measurement response.
 
 The frontend `mapQuantumToBody.ts` normalizes that JSON into body region state and entanglement links for the tile renderer.
-
-## Docker
-
-```bash
-docker compose up --build
-```
 
 ## Music Credit
 

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,20 +1,68 @@
 # Entangled Body AWS Terraform
 
-This creates the first deployment shape:
+This Terraform configuration manages the current AWS deployment:
 
 - S3 stores the static Next export from `apps/web`.
 - CloudFront serves the S3 frontend as the default origin.
 - CloudFront routes `/api/*` to the App Runner FastAPI origin.
 - The frontend can keep calling `/api/quantum/...`; Next.js does not proxy API traffic in production.
-- Optionally, Route 53 and ACM attach an apex custom domain such as `entangledbody.com`.
-- Optionally, `www.<domain>` is attached and redirected to the apex domain.
+- Route 53 and ACM attach a custom HTTPS domain such as `entangledbody.com`.
+- `www.<domain>` can also be attached and redirected to the apex domain.
 
 ## Prerequisites
 
-1. Build and push the API Docker image to ECR or ECR Public.
-2. If using private ECR, Terraform creates a default App Runner ECR access role unless you pass an existing role ARN as `apprunner_access_role_arn`.
+1. Build and push the API Docker image to private ECR.
+2. Terraform creates a default App Runner ECR access role unless you pass an existing role ARN as `apprunner_access_role_arn`.
 3. Authenticate AWS locally with credentials that can manage S3, CloudFront, and App Runner.
 4. For a custom domain, either have an existing public Route 53 hosted zone or let Terraform create one.
+
+## Deploy API Image
+
+Private ECR is recommended for the API image:
+
+```text
+<account-id>.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest
+```
+
+Create the ECR repository once if it does not already exist:
+
+```bash
+aws ecr create-repository \
+  --repository-name entangled-body-api \
+  --region us-east-1
+```
+
+Log in Docker to ECR:
+
+```bash
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com
+```
+
+App Runner expects a Linux amd64 container image. On Apple Silicon Macs, build and push with `buildx`:
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  -t <account-id>.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest \
+  -f apps/api/Dockerfile \
+  --push .
+```
+
+If the image is built without `--platform linux/amd64`, App Runner may fail with:
+
+```text
+exec /usr/local/bin/uvicorn: exec format error
+```
+
+Optional: enable ECR scan on push:
+
+```bash
+aws ecr put-image-scanning-configuration \
+  --repository-name entangled-body-api \
+  --image-scanning-configuration scanOnPush=true \
+  --region us-east-1
+```
 
 ## Apply Infrastructure
 
@@ -24,6 +72,14 @@ cp terraform.tfvars.example terraform.tfvars
 terraform init
 terraform plan
 terraform apply
+```
+
+For private ECR, set these values in `terraform.tfvars`:
+
+```hcl
+api_image_identifier      = "<account-id>.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest"
+api_image_repository_type = "ECR"
+apprunner_access_role_arn = null
 ```
 
 For a custom domain managed in Route 53, add these values to `terraform.tfvars`:
@@ -42,6 +98,8 @@ create_route53_zone = true
 ```
 
 When Terraform creates the hosted zone and the domain was registered outside Route 53, update the registrar's nameservers to the `route53_name_servers` output. If the domain is registered in Route 53 and uses the same hosted zone, no external DNS console is needed.
+
+If the domain was registered in Route 53 and Route 53 created the hosted zone, leave `route53_zone_id` unset and `create_route53_zone` as `false`; Terraform will look up the existing hosted zone by domain name.
 
 After apply, Terraform prints:
 
@@ -86,3 +144,86 @@ https://<frontend-domain>/api/quantum/health
 ```
 
 CloudFront forwards those `/api/*` requests to App Runner.
+
+## Redeploy Changes
+
+For frontend-only changes:
+
+```bash
+npm run build
+aws s3 sync apps/web/out "s3://$(terraform -chdir=infra/terraform output -raw frontend_bucket_name)" --delete
+aws cloudfront create-invalidation \
+  --distribution-id "$(terraform -chdir=infra/terraform output -raw cloudfront_distribution_id)" \
+  --paths "/*"
+```
+
+For API changes:
+
+```bash
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com
+
+docker buildx build \
+  --platform linux/amd64 \
+  -t <account-id>.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest \
+  -f apps/api/Dockerfile \
+  --push .
+```
+
+App Runner has `auto_deployments_enabled = true`, so pushing a new ECR image can trigger a backend redeploy. If it does not update immediately, trigger an App Runner redeploy from the AWS console or CLI.
+
+## Useful Commands
+
+Show all Terraform outputs:
+
+```bash
+terraform -chdir=infra/terraform output
+```
+
+Show specific outputs:
+
+```bash
+terraform -chdir=infra/terraform output -raw frontend_bucket_name
+terraform -chdir=infra/terraform output -raw cloudfront_distribution_id
+terraform -chdir=infra/terraform output -raw cloudfront_domain_name
+terraform -chdir=infra/terraform output -raw apprunner_service_url
+```
+
+Check the API through CloudFront:
+
+```bash
+curl https://<frontend-domain>/api/health
+```
+
+Check the API directly through App Runner:
+
+```bash
+curl https://$(terraform -chdir=infra/terraform output -raw apprunner_service_url)/health
+```
+
+## Git Safety
+
+Commit:
+
+- Terraform configuration files, such as `main.tf`, `variables.tf`, `outputs.tf`, and `versions.tf`.
+- `terraform.tfvars.example`.
+- `.terraform.lock.hcl`.
+
+Do not commit:
+
+- `terraform.tfvars`
+- `terraform.tfstate`
+- `terraform.tfstate.backup`
+- `.terraform/`
+
+`terraform.tfvars` contains local environment values. `terraform.tfstate` contains deployed resource state and should be protected. For team usage, move Terraform state to a remote backend such as S3 with state locking.
+
+## CI/CD Notes
+
+This deployment is currently manual. A future GitHub Actions setup can automate:
+
+- Frontend build, S3 sync, and CloudFront invalidation.
+- API `linux/amd64` Docker build, ECR push, and App Runner redeploy.
+- AWS authentication through GitHub OIDC instead of long-lived AWS access keys.
+
+Keep Terraform `apply` manual at first. A safer early CI workflow is to run `terraform plan` automatically and apply infrastructure changes only after human review.

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -2,16 +2,16 @@ project_name = "entangled-body"
 aws_region   = "us-east-1"
 
 # Private ECR example:
-# api_image_identifier      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest"
-# api_image_repository_type = "ECR"
-# apprunner_access_role_arn = null
+ api_image_identifier      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/entangled-body-api:latest"
+ api_image_repository_type = "ECR"
+ apprunner_access_role_arn = null
 
 # ECR Public example:
-api_image_identifier      = "public.ecr.aws/example/entangled-body-api:latest"
-api_image_repository_type = "ECR_PUBLIC"
+# api_image_identifier      = "public.ecr.aws/example/entangled-body-api:latest"
+# api_image_repository_type = "ECR_PUBLIC"
 
 # Optional custom domain managed in Route 53.
-# custom_domain_name        = "entangledbody.com"
+# custom_domain_name        = "example.com"
 # custom_domain_include_www = true
 # redirect_www_to_apex      = true
 


### PR DESCRIPTION
## Summary
- Updated the root README with the live demo URL and a concise AWS deployment overview
- Moved detailed deployment commands and operational notes into `infra/terraform/README.md`
- Documented the manual API image build/push flow, Terraform apply steps, frontend redeploy commands, custom domain setup, and CI/CD follow-up notes

## Related Issue
#21 

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [o] Docs
- [ ] Chore

## Checklist
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally
- [ ] Verified in preview deployment
- [ ] No secrets exposed
- [ ] Docs updated if needed

## Notes for Reviewer
Future frontend/API redeploy steps are documented under `Redeploy Changes` in infra/terraform/README.md