### PR TITLE
Fix API deploy workflow for App Runner auto deployments

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -47,7 +47,26 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Trigger App Runner deployment
+      - name: Wait for App Runner deployment
         run: |
-          aws apprunner start-deployment \
-            --service-arn "${{ vars.APP_RUNNER_SERVICE_ARN }}"
+          for attempt in {1..60}; do
+            status="$(aws apprunner describe-service \
+              --service-arn "${{ vars.APP_RUNNER_SERVICE_ARN }}" \
+              --query 'Service.Status' \
+              --output text)"
+
+            echo "App Runner status: ${status}"
+
+            if [ "${status}" = "RUNNING" ]; then
+              exit 0
+            fi
+
+            if [ "${status}" = "CREATE_FAILED" ] || [ "${status}" = "DELETE_FAILED" ]; then
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for App Runner to return to RUNNING."
+          exit 1


### PR DESCRIPTION
## Summary
- Update API deploy workflow to wait for App Runner to return to RUNNING
- Avoid calling start-deployment while App Runner auto deployment is already in progress

## Related Issue
Closes #

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Checklist
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally
- [ ] Verified in preview deployment
- [ ] No secrets exposed
- [ ] Docs updated if needed


## Notes for Reviewer
- ECR image build and push still run automatically on API changes
