### PR TITLE
Add frontend logic to make entangled body remain in 3D point cloud if qubit measurement results in 0.

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,3 +4,4 @@ IONQ_SIMULATOR_BACKEND=ionq_simulator
 IONQ_QPU_BACKEND=ionq_qpu
 IONQ_ENABLE_HARDWARE=true
 IONQ_TIMEOUT_SECONDS=120
+API_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://entangledbody.com

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -10,7 +12,14 @@ app = FastAPI(title="Entangled Body API", version="0.1.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[
+        origin.strip()
+        for origin in os.getenv(
+            "API_CORS_ORIGINS",
+            "http://localhost:3000,http://127.0.0.1:3000,https://entangledbody.com",
+        ).split(",")
+        if origin.strip()
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/apps/api/quantum/circuits.py
+++ b/apps/api/quantum/circuits.py
@@ -102,10 +102,14 @@ def _target_probability(
     interaction: str,
 ) -> float:
     if target_region == observed_region:
-        return 1.0
+        return 0.96 if interaction in {"click", "hold"} else 1.0
 
     max_distance = _max_spatial_distance(observed_region)
     distance_ratio = 0.0 if max_distance <= 0 else max(0.0, min(1.0, distance / max_distance))
+    if interaction in {"click", "hold"}:
+        one_probability = 0.965 - 0.125 * distance_ratio
+        return max(0.84, min(0.965, one_probability))
+
     one_probability = 0.995 - 0.095 * distance_ratio
     return max(0.90, min(0.995, one_probability))
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -233,6 +233,33 @@ button {
   box-shadow: inset 0 0 0 1px rgba(133, 241, 189, 0.24);
 }
 
+.scene-return-button {
+  min-width: 92px;
+  height: 58px;
+  border: 1px solid rgba(196, 223, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(9, 14, 21, 0.72);
+  color: rgba(245, 247, 251, 0.84);
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 800;
+  backdrop-filter: blur(14px);
+  transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease, color 160ms ease;
+}
+
+.scene-return-button:hover,
+.scene-return-button:focus-visible {
+  border-color: rgba(133, 241, 189, 0.42);
+  background: rgba(98, 215, 255, 0.14);
+  color: #f5f7fb;
+  outline: none;
+}
+
+.scene-return-button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
 .music-toggle {
   display: grid;
   place-items: center;

--- a/apps/web/components/BodyScene.tsx
+++ b/apps/web/components/BodyScene.tsx
@@ -51,6 +51,7 @@ export function BodyScene() {
   const [connectionBreakPoint, setConnectionBreakPoint] = useState<Vector3Tuple | null>(null);
   const [connectionBreakProgress, setConnectionBreakProgress] = useState(0);
   const [inspectedNode, setInspectedNode] = useState<InspectedNode | null>(null);
+  const [collapseZeroBitRegions, setCollapseZeroBitRegions] = useState<BodyRegion[]>([]);
   const [uiScale, setUiScale] = useState(1);
   const lastHoverRegion = useRef<BodyRegion | null>(null);
   const collapseFrame = useRef<number | null>(null);
@@ -58,6 +59,7 @@ export function BodyScene() {
   const stableReturnFrame = useRef<number | null>(null);
   const stableReturnTimeout = useRef<number | null>(null);
   const collapseLocked = modelStable || collapseFrame.current !== null || stableReturnTimeout.current !== null || stableReturnFrame.current !== null;
+  const zeroBitRegions = modelStable ? collapseZeroBitRegions : [];
 
   useEffect(() => {
     return () => {
@@ -98,7 +100,45 @@ export function BodyScene() {
     connectionBreakFrame.current = requestAnimationFrame(tick);
   }, [hoveredPoint]);
 
-  const startCollapseAnimation = useCallback((point?: Vector3Tuple, onReturnComplete?: () => void) => {
+  const startReturnAnimation = useCallback((onReturnComplete?: () => void) => {
+    if (collapseFrame.current !== null) {
+      cancelAnimationFrame(collapseFrame.current);
+      collapseFrame.current = null;
+    }
+    if (stableReturnFrame.current !== null) cancelAnimationFrame(stableReturnFrame.current);
+    if (stableReturnTimeout.current !== null) {
+      window.clearTimeout(stableReturnTimeout.current);
+      stableReturnTimeout.current = null;
+    }
+
+    const returnStarted = performance.now();
+    const returnTick = (returnNow: number) => {
+      const returnProgress = Math.min(1, (returnNow - returnStarted) / 2600);
+      const reverseProgress = 1 - returnProgress;
+
+      setStableProgress(reverseProgress);
+      setCollapseProgress(reverseProgress);
+      setConnectionBreakProgress(reverseProgress);
+
+      if (returnProgress < 1) {
+        stableReturnFrame.current = requestAnimationFrame(returnTick);
+      } else {
+        stableReturnFrame.current = null;
+        setMode("superposition");
+        setCollapseProgress(0);
+        setModelStable(false);
+        setStablePoint(null);
+        setStableProgress(0);
+        setConnectionBreakPoint(null);
+        setConnectionBreakProgress(0);
+        onReturnComplete?.();
+      }
+    };
+
+    stableReturnFrame.current = requestAnimationFrame(returnTick);
+  }, []);
+
+  const startCollapseAnimation = useCallback((point?: Vector3Tuple) => {
     if (collapseFrame.current !== null) cancelAnimationFrame(collapseFrame.current);
     if (stableReturnFrame.current !== null) {
       cancelAnimationFrame(stableReturnFrame.current);
@@ -123,34 +163,6 @@ export function BodyScene() {
         collapseFrame.current = requestAnimationFrame(tick);
       } else {
         collapseFrame.current = null;
-        stableReturnTimeout.current = window.setTimeout(() => {
-          stableReturnTimeout.current = null;
-          const returnStarted = performance.now();
-          const returnTick = (returnNow: number) => {
-            const returnProgress = Math.min(1, (returnNow - returnStarted) / 2600);
-            const reverseProgress = 1 - returnProgress;
-
-            setStableProgress(reverseProgress);
-            setCollapseProgress(reverseProgress);
-            setConnectionBreakProgress(reverseProgress);
-
-            if (returnProgress < 1) {
-              stableReturnFrame.current = requestAnimationFrame(returnTick);
-            } else {
-              stableReturnFrame.current = null;
-              setMode("superposition");
-              setCollapseProgress(0);
-              setModelStable(false);
-              setStablePoint(null);
-              setStableProgress(0);
-              setConnectionBreakPoint(null);
-              setConnectionBreakProgress(0);
-              onReturnComplete?.();
-            }
-          };
-
-          stableReturnFrame.current = requestAnimationFrame(returnTick);
-        }, 3400);
       }
     };
 
@@ -250,20 +262,29 @@ export function BodyScene() {
       setInspectedNode(null);
       setHoveredRegion(targetRegion);
       setHoveredPoint(point ?? hoveredPoint);
-      startConnectionBreakAnimation(point);
-      startCollapseAnimation(point, () => {
-        void regenerateEntangledState(targetRegion);
-      });
       const payload = await measure(targetRegion, 1, 1, { interaction: "hold", backend: quantumBackend });
       const mapped = mapQuantumToBody(payload);
+      const collapsedZeroBitRegions = mapped.nodeStates.filter((node) => node.measuredBit === "0").map((node) => node.region);
+      setCollapseZeroBitRegions(collapsedZeroBitRegions);
       setLatestMeasurement(payload as QuantumMeasurementPayload);
       setQuantumState(mapped);
+      startConnectionBreakAnimation(point);
+      startCollapseAnimation(point);
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : "Global collapse failed.");
     } finally {
       setLoading(false);
     }
-  }, [collapseLocked, hoveredPoint, hoveredRegion, loading, quantumBackend, regenerateEntangledState, startCollapseAnimation, startConnectionBreakAnimation]);
+  }, [collapseLocked, hoveredPoint, hoveredRegion, loading, quantumBackend, startCollapseAnimation, startConnectionBreakAnimation]);
+
+  const handleReturnToEntangledState = useCallback(() => {
+    if (!modelStable && collapseFrame.current === null) return;
+    const targetRegion = hoveredRegion ?? "torso";
+    startReturnAnimation(() => {
+      setCollapseZeroBitRegions([]);
+      void regenerateEntangledState(targetRegion);
+    });
+  }, [hoveredRegion, modelStable, regenerateEntangledState, startReturnAnimation]);
 
   const applyStrongMeasurement = useCallback((region: BodyRegion, point?: Vector3Tuple, nodeIndex?: number) => {
     if (appMode === "inspect") {
@@ -321,6 +342,7 @@ export function BodyScene() {
     setAppMode(nextMode);
     setError(null);
     setInspectedNode(null);
+    setCollapseZeroBitRegions([]);
     if (nextMode === "inspect") {
       if (connectionBreakFrame.current !== null) {
         cancelAnimationFrame(connectionBreakFrame.current);
@@ -353,6 +375,7 @@ export function BodyScene() {
             onHoverRegion={applyWeakMeasurement}
             onMeasureRegion={applyStrongMeasurement}
             onGlobalCollapse={handleGlobalCollapse}
+            zeroBitRegions={zeroBitRegions}
             onReady={handleModelReady}
             stable={modelStable}
             stablePoint={stablePoint}
@@ -373,8 +396,18 @@ export function BodyScene() {
           <button type="button" className={appMode === "measurement" ? "scene-mode-switch__button scene-mode-switch__button--active" : "scene-mode-switch__button"} onClick={() => switchAppMode("measurement")}>
             Measurement
           </button>
-        </div>
-        <button
+	        </div>
+        {appMode === "measurement" && modelStable ? (
+          <button
+            type="button"
+            className="scene-return-button"
+            onClick={handleReturnToEntangledState}
+            disabled={stableReturnFrame.current !== null}
+          >
+            Return
+          </button>
+        ) : null}
+	        <button
           type="button"
           className={!musicMuted ? "music-toggle music-toggle--playing" : "music-toggle"}
           onClick={toggleMusicMuted}

--- a/apps/web/components/OriginalGlbModel.tsx
+++ b/apps/web/components/OriginalGlbModel.tsx
@@ -20,6 +20,8 @@ const NERVOUS_LINE_RADIUS = 0.72;
 const NERVOUS_PATH_RADIUS = 0.2;
 const NERVOUS_TRUNK_SEGMENTS = 12;
 const HOVER_COLOR_RADIUS = 0.72;
+const BODY_REGION_COUNT = 14;
+const emptyZeroBitRegionMask = new Float32Array(BODY_REGION_COUNT);
 
 type OriginalGlbModelProps = {
   modelUrl: string;
@@ -28,6 +30,7 @@ type OriginalGlbModelProps = {
   onHoverRegion: (region: BodyRegion | null, point?: Vector3Tuple) => void;
   onMeasureRegion: (region: BodyRegion, point?: Vector3Tuple, nodeIndex?: number) => void;
   onGlobalCollapse: () => void;
+  zeroBitRegions?: BodyRegion[];
   onReady?: () => void;
   stable: boolean;
   stablePoint: Vector3Tuple | null;
@@ -61,13 +64,13 @@ type WaveMaterialBinding = {
 
 type WaveMaterial = Material & {
   userData: {
-    entangledUniforms?: Record<string, { value: number | Vector3 }>;
+    entangledUniforms?: Record<string, { value: number | Vector3 | Float32Array }>;
   };
 };
 
 type MaskedPointMaterial = PointsMaterial & {
   userData: {
-    hoverMaskUniforms?: Record<string, { value: number | Vector3 }>;
+    hoverMaskUniforms?: Record<string, { value: number | Vector3 | Float32Array }>;
   };
 };
 
@@ -147,6 +150,7 @@ export function OriginalGlbModel({
   onHoverRegion,
   onMeasureRegion,
   onGlobalCollapse,
+  zeroBitRegions = [],
   onReady,
   stable,
   stablePoint,
@@ -179,11 +183,12 @@ export function OriginalGlbModel({
       const bindings: WaveMaterialBinding[] = [];
 
       scene.traverse((object) => {
-        object.frustumCulled = false;
-        const mesh = object as Mesh;
-        if (!mesh.isMesh || !mesh.material) return;
+	        object.frustumCulled = false;
+	        const mesh = object as Mesh;
+	        if (!mesh.isMesh || !mesh.material) return;
+        applyBodyRegionAttribute(mesh);
 
-        if (Array.isArray(mesh.material)) {
+	        if (Array.isArray(mesh.material)) {
           mesh.material = mesh.material.map((material) => prepareMaterial(material, opacity));
           for (const material of mesh.material) {
             bindings.push({ mesh, material });
@@ -249,14 +254,16 @@ export function OriginalGlbModel({
     const hasHoverPoint = !stable && hoveredPoint ? 1 : 0;
     const hasStablePoint = stable && stablePoint ? 1 : 0;
     const surfaceInteractionPoint = stable && stablePoint ? stablePoint : hoveredPoint;
+    const zeroBitRegionMask = stable ? buildZeroBitRegionMask(zeroBitRegions) : emptyZeroBitRegionMask;
 
     updateSurfaceGlowPointColors(model.surfaceGlowPointGeometry, model.scene, surfaceInteractionPoint);
-    updateMaskedPointMaterial(surfaceGlowMaterial, surfaceInteractionPoint, model.scene, surfaceGlowOpacityForFrame(stable, stableProgress, hoveredPoint, stablePoint));
-    updateMaskedPointMaterial(surfacePointMaterial, surfaceInteractionPoint, model.scene, surfacePointOpacityForFrame(stable, stableProgress, hoveredPoint, stablePoint));
+    updateMaskedPointMaterial(surfaceGlowMaterial, surfaceInteractionPoint, model.scene, surfaceGlowOpacityForFrame(hoveredPoint, stablePoint), stable, stableProgress, zeroBitRegionMask);
+    updateMaskedPointMaterial(surfacePointMaterial, surfaceInteractionPoint, model.scene, surfacePointOpacityForFrame(hoveredPoint, stablePoint), stable, stableProgress, zeroBitRegionMask);
     for (const binding of model.bindings) {
       const material = binding.material;
-      material.opacity = effectiveOpacity;
-      material.transparent = !revealComplete;
+      material.opacity = zeroBitRegions.length > 0 ? Math.max(0.07, Math.min(0.42, opacity + breath * 0.028)) : effectiveOpacity;
+      material.transparent = zeroBitRegions.length > 0 || !revealComplete;
+      material.alphaHash = false;
       material.depthWrite = true;
       material.needsUpdate = true;
       const uniforms = material.userData.entangledUniforms;
@@ -280,14 +287,16 @@ export function OriginalGlbModel({
       uniforms.uHasStablePoint.value = hasStablePoint;
       uniforms.uStablePoint.value = localStable;
       uniforms.uStableProgress.value = stableProgress;
-      uniforms.uWaveStrength.value = effectiveWaveStrength;
+      uniforms.uWaveStrength.value = zeroBitRegions.length > 0 ? waveStrength : effectiveWaveStrength;
       uniforms.uBaseOpacity.value = material.opacity;
+      uniforms.uExcludedRegionMask.value = zeroBitRegionMask;
     }
   });
 
   if (!model) return null;
 
   const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
+  const keepMaskedSurfacePoints = stable && zeroBitRegions.length > 0;
   const activeFixedPointSource = connectionBreakPoint ?? (stable && stablePoint ? stablePoint : hoveredPoint);
   const showFullEntanglement = Boolean(hoveredPoint || connectionBreakPoint || stablePoint);
   const disconnectEntanglement = Boolean(connectionBreakPoint);
@@ -312,7 +321,7 @@ export function OriginalGlbModel({
 
   return (
     <group position={model.position} scale={model.scale}>
-      {surfaceFade > 0.001 ? (
+      {surfaceFade > 0.001 || keepMaskedSurfacePoints ? (
         <>
           <points geometry={model.surfaceGlowPointGeometry} frustumCulled={false} renderOrder={3} raycast={ignorePointRaycast}>
             <primitive object={surfaceGlowMaterial} attach="material" />
@@ -420,26 +429,27 @@ function getFixedRegionPoints(model: LoadedModel): FixedRegionPoint[] {
   const depth = Math.max(0.001, model.maxZ - model.minZ);
   const centerX = (model.minX + model.maxX) * 0.5;
   const centerZ = (model.minZ + model.maxZ) * 0.5;
-  const frontZ = centerZ + depth * 0.22;
-  const backZ = centerZ - depth * 0.24;
-  const y = (ratio: number, offset = 0) => model.minY + height * (ratio + 0.035 + offset);
-  const x = (ratio: number) => centerX + width * ratio;
+  const point = (xRatio: number, yRatio: number, zRatio: number): [number, number, number] => [
+    centerX + width * xRatio,
+    model.minY + height * yRatio,
+    centerZ + depth * zRatio,
+  ];
 
   return [
-    { label: "node0", position: [centerX, y(0.86), frontZ] },
-    { label: "node1", position: [centerX, y(0.66), frontZ] },
-    { label: "node2", position: [centerX, y(0.52), frontZ] },
-    { label: "node3", position: [centerX, y(0.61), backZ] },
-    { label: "node4", position: [x(-0.23), y(0.7), centerZ] },
-    { label: "node5", position: [x(0.23), y(0.7), centerZ] },
-    { label: "node6", position: [x(-0.36), y(0.57), centerZ] },
-    { label: "node7", position: [x(0.36), y(0.57), centerZ] },
-    { label: "node8", position: [x(-0.43), y(0.39, 0.035), frontZ] },
-    { label: "node9", position: [x(0.43), y(0.39, 0.035), frontZ] },
-    { label: "node10", position: [x(-0.13), y(0.28), centerZ] },
-    { label: "node11", position: [x(0.13), y(0.28), centerZ] },
-    { label: "node12", position: [x(-0.14), y(0.04, -0.035), frontZ] },
-    { label: "node13", position: [x(0.14), y(0.04, -0.035), frontZ] },
+    { label: "node0", position: point(0, 0.903, 0.220) },
+    { label: "node1", position: point(0, 0.733, 0.214) },
+    { label: "node2", position: point(0, 0.570, 0.208) },
+    { label: "node3", position: point(0, 0.721, -0.234) },
+    { label: "node4", position: point(-0.31, 0.766, 0.12) },
+    { label: "node5", position: point(0.31, 0.765, 0.12) },
+    { label: "node6", position: point(-0.391, 0.639, 0.126) },
+    { label: "node7", position: point(0.392, 0.637, 0.129) },
+    { label: "node8", position: point(-0.407, 0.483, 0.191) },
+    { label: "node9", position: point(0.406, 0.476, 0.149) },
+    { label: "node10", position: point(-0.099, 0.414, 0.175) },
+    { label: "node11", position: point(0.099, 0.414, 0.175) },
+    { label: "node12", position: point(-0.111, 0.033, 0.258) },
+    { label: "node13", position: point(0.111, 0.033, 0.258) },
   ];
 }
 
@@ -637,10 +647,12 @@ function distanceSqBetweenFixedPoints(left: FixedRegionPoint, right: FixedRegion
 
 function sampleSurfaceGeometry(scene: Object3D, pointCount: number): { pointGeometry: BufferGeometry; glowPointGeometry: BufferGeometry; lineGeometry: BufferGeometry } {
   scene.updateMatrixWorld(true);
+  const sceneBox = new Box3().setFromObject(scene);
   const sources = collectSurfaceSources(scene).map((mesh) => bakeSurfaceSource(scene, mesh));
   const totalWeight = sources.reduce((sum, source) => sum + source.weight, 0) || 1;
   const positions: number[] = [];
   const colors: number[] = [];
+  const bodyRegionIds: number[] = [];
   const target = new Vector3();
   const normal = new Vector3();
 
@@ -649,11 +661,12 @@ function sampleSurfaceGeometry(scene: Object3D, pointCount: number): { pointGeom
     const sampler = new MeshSurfaceSampler(source.bakedMesh).build();
 
     for (let index = 0; index < count && positions.length / 3 < pointCount; index += 1) {
-      sampler.sample(target, normal);
-      target.addScaledVector(normal, SURFACE_POINT_OFFSET);
-      positions.push(target.x, target.y, target.z);
-      colors.push(1, 1, 1);
-    }
+	      sampler.sample(target, normal);
+	      target.addScaledVector(normal, SURFACE_POINT_OFFSET);
+	      positions.push(target.x, target.y, target.z);
+	      colors.push(1, 1, 1);
+      bodyRegionIds.push(bodyRegionIdForSpatialPoint(target.x, target.y, target.z, sceneBox));
+	    }
 
     source.bakedGeometry.dispose();
   }
@@ -661,6 +674,7 @@ function sampleSurfaceGeometry(scene: Object3D, pointCount: number): { pointGeom
   const pointGeometry = new BufferGeometry();
   pointGeometry.setAttribute("position", new Float32BufferAttribute(positions, 3));
   pointGeometry.setAttribute("color", new Float32BufferAttribute(colors, 3));
+  pointGeometry.setAttribute("bodyRegionId", new Float32BufferAttribute(bodyRegionIds, 1));
   pointGeometry.computeBoundingSphere();
 
   const glowPointGeometry = pointGeometry.clone();
@@ -1040,16 +1054,172 @@ function isSkinnedMesh(mesh: Mesh): mesh is SkinnedMesh {
 
 function ignorePointRaycast(): void {}
 
-function surfaceGlowOpacityForFrame(stable: boolean, stableProgress: number, hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
-  const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
-  const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
-  return (hasSurfaceInteraction ? 0.34 : 0.05) * surfaceFade;
+function applyBodyRegionAttribute(mesh: Mesh): void {
+  const geometry = mesh.geometry;
+  if (!geometry || geometry.getAttribute("bodyRegionId")) return;
+
+  const position = geometry.getAttribute("position");
+  if (!position) return;
+
+  const skinIndex = geometry.getAttribute("skinIndex");
+  const skinWeight = geometry.getAttribute("skinWeight");
+  const bones = isSkinnedMesh(mesh) ? mesh.skeleton.bones : [];
+  const regionIds = new Float32Array(position.count);
+  if (!geometry.boundingBox) geometry.computeBoundingBox();
+  const bounds = geometry.boundingBox;
+  const minY = bounds?.min.y ?? 0;
+  const maxY = bounds?.max.y ?? 1;
+  const minZ = bounds?.min.z ?? -1;
+  const maxZ = bounds?.max.z ?? 1;
+
+  for (let index = 0; index < position.count; index += 1) {
+    const x = position.getX(index);
+    const y = position.getY(index);
+    const z = position.getZ(index);
+    const spatialOverride = bodyMeshRegionSpatialOverride(x, y, z, minY, maxY, minZ, maxZ);
+    if (spatialOverride !== null) {
+      regionIds[index] = spatialOverride;
+      continue;
+    }
+
+    if (skinIndex && skinWeight && bones.length > 0) {
+      let bestWeight = -1;
+      let bestJoint = 0;
+      for (let item = 0; item < 4; item += 1) {
+        const weight = skinWeight.getComponent(index, item);
+        if (weight > bestWeight) {
+          bestWeight = weight;
+          bestJoint = skinIndex.getComponent(index, item);
+        }
+      }
+      const regionId = bodyRegionIdForBoneName(bones[bestJoint]?.name ?? "");
+      regionIds[index] = regionId >= 0 ? regionId : bodyRegionIdForVertex("", x, y, z, minY, maxY, minZ, maxZ);
+      continue;
+    }
+
+    regionIds[index] = bodyRegionIdForVertex(
+      "",
+      x,
+      y,
+      z,
+      minY,
+      maxY,
+      minZ,
+      maxZ,
+    );
+  }
+
+  geometry.setAttribute("bodyRegionId", new Float32BufferAttribute(regionIds, 1));
 }
 
-function surfacePointOpacityForFrame(stable: boolean, stableProgress: number, hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
-  const surfaceFade = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
+function bodyMeshRegionSpatialOverride(x: number, y: number, z: number, minY: number, maxY: number, minZ: number, maxZ: number): number | null {
+  const height = Math.max(0.001, maxY - minY);
+  const depth = Math.max(0.001, maxZ - minZ);
+  const normalizedY = (y - minY) / height;
+  const backThreshold = minZ + depth * 0.47;
+  const absX = Math.abs(x);
+
+  if (z < backThreshold && normalizedY > 0.48) return regionToId("oxygenTank");
+  if (absX > 3.05 && y > 5.15 && y < 7.15) return x < 0 ? regionToId("rightHand") : regionToId("leftHand");
+  if (absX > 1.95 && absX <= 3.35 && y > 6.35 && y < 9.25) return x < 0 ? regionToId("rightArm") : regionToId("leftArm");
+  if (absX > 0.95 && absX <= 2.3 && y > 8.15 && y < 9.45 && z > -0.85) return x < 0 ? regionToId("rightShoulder") : regionToId("leftShoulder");
+  return null;
+}
+
+function pointCloudRegionSpatialOverride(x: number, y: number, z: number, minY: number, maxY: number, minZ: number, maxZ: number): number | null {
+  const height = Math.max(0.001, maxY - minY);
+  const depth = Math.max(0.001, maxZ - minZ);
+  const normalizedY = (y - minY) / height;
+  const backThreshold = minZ + depth * 0.47;
+  const absX = Math.abs(x);
+
+  if (z < backThreshold && normalizedY > 0.48) return regionToId("oxygenTank");
+  if (absX > 2.95 && y > 5.05 && y < 7.3) return x < 0 ? regionToId("rightHand") : regionToId("leftHand");
+  if (absX > 1.95 && absX <= 3.35 && y > 6.35 && y < 9.25) return x < 0 ? regionToId("rightArm") : regionToId("leftArm");
+  if (absX > 1.0 && absX <= 2.35 && y > 8.1 && y < 9.5 && z > -0.75) return x < 0 ? regionToId("rightShoulder") : regionToId("leftShoulder");
+  return null;
+}
+
+function bodyRegionIdForBoneName(boneName: string): number {
+  const lower = boneName.toLowerCase();
+  if (lower.includes("head") || lower.includes("neck")) return regionToId("head");
+  if (lower.includes("clav.r")) return regionToId("rightShoulder");
+  if (lower.includes("clav.l")) return regionToId("leftShoulder");
+  if (lower.includes(".r") || lower.includes("_r")) {
+    if (lower.includes("finger") || lower.includes("thumb") || lower.includes("hand")) return regionToId("rightHand");
+    if (lower.includes("arm")) return regionToId("rightArm");
+    if (lower.includes("foot") || lower.includes("toes")) return regionToId("rightFoot");
+    if (lower.includes("leg") || lower.includes("hip")) return regionToId("rightLeg");
+  }
+  if (lower.includes(".l") || lower.includes("_l")) {
+    if (lower.includes("finger") || lower.includes("thumb") || lower.includes("hand")) return regionToId("leftHand");
+    if (lower.includes("arm")) return regionToId("leftArm");
+    if (lower.includes("foot") || lower.includes("toes")) return regionToId("leftFoot");
+    if (lower.includes("leg") || lower.includes("hip")) return regionToId("leftLeg");
+  }
+  if (lower.includes("spine3") || lower.includes("spine4")) return regionToId("chest");
+  if (lower.includes("spine") || lower.includes("master") || lower.includes("root")) return regionToId("torso");
+  return -1;
+}
+
+function bodyRegionIdForVertex(boneName: string, x: number, y: number, z: number, minY: number, maxY: number, minZ: number, maxZ: number): number {
+  const lower = boneName.toLowerCase();
+  const height = Math.max(0.001, maxY - minY);
+  const depth = Math.max(0.001, maxZ - minZ);
+  const normalizedY = (y - minY) / height;
+  const backThreshold = minZ + depth * 0.47;
+
+  if (normalizedY < 0.1) return x < 0 ? regionToId("rightFoot") : regionToId("leftFoot");
+  if ((lower.includes("foot") || lower.includes("toes")) && (lower.includes(".r") || lower.includes("_r"))) return regionToId("rightFoot");
+  if ((lower.includes("foot") || lower.includes("toes")) && (lower.includes(".l") || lower.includes("_l"))) return regionToId("leftFoot");
+  if (z < backThreshold && normalizedY > 0.48) return regionToId("oxygenTank");
+  if (lower.includes("head") || lower.includes("neck")) return regionToId("head");
+  if (lower.includes("clav.r")) return regionToId("rightShoulder");
+  if (lower.includes("clav.l")) return regionToId("leftShoulder");
+  if (lower.includes(".r") || lower.includes("_r")) {
+    if (lower.includes("finger") || lower.includes("thumb") || lower.includes("hand")) return regionToId("rightHand");
+    if (lower.includes("arm")) return regionToId("rightArm");
+    if (lower.includes("leg") || lower.includes("hip")) return regionToId("rightLeg");
+  }
+  if (lower.includes(".l") || lower.includes("_l")) {
+    if (lower.includes("finger") || lower.includes("thumb") || lower.includes("hand")) return regionToId("leftHand");
+    if (lower.includes("arm")) return regionToId("leftArm");
+    if (lower.includes("leg") || lower.includes("hip")) return regionToId("leftLeg");
+  }
+  if (lower.includes("spine3") || lower.includes("spine4")) return regionToId("chest");
+  if (lower.includes("spine") || lower.includes("master") || lower.includes("root")) return regionToId("torso");
+
+  if (normalizedY > 0.78) return regionToId("head");
+  if (normalizedY > 0.6) return x < 0 ? regionToId("rightShoulder") : regionToId("leftShoulder");
+  if (normalizedY > 0.42) return regionToId("torso");
+  return x < 0 ? regionToId("rightLeg") : regionToId("leftLeg");
+}
+
+function bodyRegionIdForSpatialPoint(x: number, y: number, z: number, box: Box3): number {
+  const override = pointCloudRegionSpatialOverride(x, y, z, box.min.y, box.max.y, box.min.z, box.max.z);
+  if (override !== null) return override;
+  return bodyRegionIdForVertex("", x, y, z, box.min.y, box.max.y, box.min.z, box.max.z);
+}
+
+function buildZeroBitRegionMask(regions: BodyRegion[]): Float32Array {
+  if (regions.length === 0) return emptyZeroBitRegionMask;
+
+  const mask = new Float32Array(BODY_REGION_COUNT);
+  for (const region of regions) {
+    const id = regionToId(region);
+    if (id >= 0 && id < BODY_REGION_COUNT) mask[id] = 1;
+  }
+  return mask;
+}
+
+function surfaceGlowOpacityForFrame(hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
   const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
-  return (hasSurfaceInteraction ? 0.34 : 0.68) * surfaceFade;
+  return hasSurfaceInteraction ? 0.34 : 0.05;
+}
+
+function surfacePointOpacityForFrame(hoveredPoint: Vector3Tuple | null, stablePoint: Vector3Tuple | null): number {
+  const hasSurfaceInteraction = Boolean(hoveredPoint || stablePoint);
+  return hasSurfaceInteraction ? 0.34 : 0.68;
 }
 
 function prepareMaskedPointMaterial({
@@ -1072,37 +1242,65 @@ function prepareMaskedPointMaterial({
     depthWrite: false,
   }) as MaskedPointMaterial;
 
-  material.onBeforeCompile = (shader) => {
-    shader.uniforms.uHasHiddenPoint = { value: 0 };
-    shader.uniforms.uHiddenPoint = { value: new Vector3() };
-    shader.uniforms.uHiddenRadius = { value: HOVER_COLOR_RADIUS * 0.92 };
-    material.userData.hoverMaskUniforms = shader.uniforms;
+	  material.onBeforeCompile = (shader) => {
+	    shader.uniforms.uHasHiddenPoint = { value: 0 };
+	    shader.uniforms.uHiddenPoint = { value: new Vector3() };
+	    shader.uniforms.uHiddenRadius = { value: HOVER_COLOR_RADIUS * 0.92 };
+	    shader.uniforms.uSurfaceFade = { value: 1 };
+    shader.uniforms.uExcludedRegionMask = { value: new Float32Array(BODY_REGION_COUNT) };
+	    material.userData.hoverMaskUniforms = shader.uniforms;
 
     shader.vertexShader = shader.vertexShader
       .replace(
         "void main() {",
         `
-uniform float uHasHiddenPoint;
-uniform vec3 uHiddenPoint;
-uniform float uHiddenRadius;
-varying float vPointCloudVisibility;
+	uniform float uHasHiddenPoint;
+	uniform vec3 uHiddenPoint;
+	uniform float uHiddenRadius;
+uniform float uExcludedRegionMask[${BODY_REGION_COUNT}];
+attribute float bodyRegionId;
+	varying float vPointCloudVisibility;
+varying float vPointBodyRegionId;
 
-void main() {`,
+float pointRegionExcluded(float regionId) {
+  float mask = 0.0;
+  for (int i = 0; i < ${BODY_REGION_COUNT}; i++) {
+    float selected = 1.0 - step(0.5, abs(regionId - float(i)));
+    mask = max(mask, selected * uExcludedRegionMask[i]);
+  }
+  return mask;
+}
+
+	void main() {`,
       )
       .replace(
-        "#include <begin_vertex>",
-        `#include <begin_vertex>
-  float hiddenInfluence = uHasHiddenPoint * (1.0 - smoothstep(uHiddenRadius * 0.55, uHiddenRadius, distance(transformed, uHiddenPoint)));
-  vPointCloudVisibility = 1.0 - hiddenInfluence;`,
-      );
+	        "#include <begin_vertex>",
+		        `#include <begin_vertex>
+		  float hiddenInfluence = uHasHiddenPoint * (1.0 - smoothstep(uHiddenRadius * 0.55, uHiddenRadius, distance(transformed, uHiddenPoint)));
+      float excludedRegion = pointRegionExcluded(bodyRegionId);
+		  vPointCloudVisibility = mix(1.0 - hiddenInfluence, 1.0, excludedRegion);
+      vPointBodyRegionId = bodyRegionId;`,
+	      );
 
     shader.fragmentShader = shader.fragmentShader
       .replace(
         "void main() {",
         `
-varying float vPointCloudVisibility;
+	uniform float uSurfaceFade;
+uniform float uExcludedRegionMask[${BODY_REGION_COUNT}];
+	varying float vPointCloudVisibility;
+varying float vPointBodyRegionId;
 
-void main() {`,
+float pointFragmentRegionExcluded(float regionId) {
+  float mask = 0.0;
+  for (int i = 0; i < ${BODY_REGION_COUNT}; i++) {
+    float selected = 1.0 - step(0.5, abs(regionId - float(i)));
+    mask = max(mask, selected * uExcludedRegionMask[i]);
+  }
+  return mask;
+}
+	
+	void main() {`,
       )
       .replace(
         "#include <clipping_planes_fragment>",
@@ -1110,9 +1308,11 @@ void main() {`,
 if (vPointCloudVisibility <= 0.02) discard;`,
       )
       .replace(
-        "#include <opaque_fragment>",
-        `diffuseColor.a *= smoothstep(0.0, 1.0, vPointCloudVisibility);
-#include <opaque_fragment>`,
+	        "#include <opaque_fragment>",
+		        `float excludedRegion = pointFragmentRegionExcluded(vPointBodyRegionId);
+float maskedSurfaceFade = mix(uSurfaceFade, 1.0, excludedRegion);
+diffuseColor.a *= smoothstep(0.0, 1.0, vPointCloudVisibility) * maskedSurfaceFade;
+		#include <opaque_fragment>`,
       );
   };
 
@@ -1120,11 +1320,22 @@ if (vPointCloudVisibility <= 0.02) discard;`,
   return material;
 }
 
-function updateMaskedPointMaterial(material: MaskedPointMaterial, interactionPoint: Vector3Tuple | null, scene: Object3D, opacity: number): void {
+function updateMaskedPointMaterial(
+  material: MaskedPointMaterial,
+  interactionPoint: Vector3Tuple | null,
+  scene: Object3D,
+  opacity: number,
+  stable: boolean,
+  stableProgress: number,
+  excludedRegionMask: Float32Array,
+): void {
   material.opacity = opacity;
 
   const uniforms = material.userData.hoverMaskUniforms;
   if (!uniforms) return;
+
+  uniforms.uSurfaceFade.value = stable ? 1 - smoothstep(0.08, 0.82, stableProgress) : 1;
+  uniforms.uExcludedRegionMask.value = excludedRegionMask;
 
   uniforms.uHasHiddenPoint.value = interactionPoint ? 1 : 0;
   if (interactionPoint) {
@@ -1137,6 +1348,7 @@ function updateMaskedPointMaterial(material: MaskedPointMaterial, interactionPoi
 function prepareMaterial(source: Material, opacity: number): WaveMaterial {
   const material = source.clone() as WaveMaterial;
   material.transparent = true;
+  material.alphaHash = false;
   material.opacity = opacity;
   material.depthWrite = true;
   material.onBeforeCompile = (shader) => {
@@ -1147,10 +1359,11 @@ function prepareMaterial(source: Material, opacity: number): WaveMaterial {
     shader.uniforms.uHoverRadius = { value: 0.92 };
     shader.uniforms.uHasStablePoint = { value: 0 };
     shader.uniforms.uStablePoint = { value: new Vector3() };
-    shader.uniforms.uStableProgress = { value: 0 };
-    shader.uniforms.uWaveStrength = { value: 1 };
-    shader.uniforms.uBaseOpacity = { value: opacity };
-    material.userData.entangledUniforms = shader.uniforms;
+	    shader.uniforms.uStableProgress = { value: 0 };
+	    shader.uniforms.uWaveStrength = { value: 1 };
+	    shader.uniforms.uBaseOpacity = { value: opacity };
+    shader.uniforms.uExcludedRegionMask = { value: new Float32Array(BODY_REGION_COUNT) };
+	    material.userData.entangledUniforms = shader.uniforms;
 
     shader.vertexShader = shader.vertexShader
       .replace(
@@ -1162,16 +1375,28 @@ uniform float uHasHoverPoint;
 uniform vec3 uHoverPoint;
 uniform float uHoverRadius;
 uniform float uHasStablePoint;
-uniform vec3 uStablePoint;
-uniform float uStableProgress;
-uniform float uWaveStrength;
-varying float vEntangledHover;
-varying float vStableReveal;
+	uniform vec3 uStablePoint;
+	uniform float uStableProgress;
+	uniform float uWaveStrength;
+uniform float uExcludedRegionMask[${BODY_REGION_COUNT}];
+attribute float bodyRegionId;
+	varying float vEntangledHover;
+	varying float vStableReveal;
+varying float vBodyRegionId;
 
-float entangledMask(vec3 p) {
-  if (uHasHoverPoint < 0.5) return 0.0;
-  float distanceToCursor = distance(p, uHoverPoint);
-  return 1.0 - smoothstep(uHoverRadius * 0.45, uHoverRadius, distanceToCursor);
+	float entangledMask(vec3 p) {
+	  if (uHasHoverPoint < 0.5) return 0.0;
+	  float distanceToCursor = distance(p, uHoverPoint);
+	  return 1.0 - smoothstep(uHoverRadius * 0.45, uHoverRadius, distanceToCursor);
+	}
+
+float excludedRegionMask(float regionId) {
+  float mask = 0.0;
+  for (int i = 0; i < ${BODY_REGION_COUNT}; i++) {
+    float selected = 1.0 - step(0.5, abs(regionId - float(i)));
+    mask = max(mask, selected * uExcludedRegionMask[i]);
+  }
+  return mask;
 }
 
 void main() {`,
@@ -1179,10 +1404,12 @@ void main() {`,
       .replace(
         "#include <skinning_vertex>",
         `#include <skinning_vertex>
-  vEntangledHover = entangledMask(transformed);
-  float stableRadius = mix(0.0, 18.0, smoothstep(0.0, 1.0, uStableProgress));
-  float stableDistance = distance(transformed, uStablePoint);
-  vStableReveal = uHasStablePoint * (1.0 - smoothstep(stableRadius * 0.52, stableRadius, stableDistance));
+	  vEntangledHover = entangledMask(transformed);
+		  float stableRadius = mix(0.0, 18.0, smoothstep(0.0, 1.0, uStableProgress));
+		  float stableDistance = distance(transformed, uStablePoint);
+    vBodyRegionId = bodyRegionId;
+    float bodyRegionExclusion = excludedRegionMask(bodyRegionId);
+	  vStableReveal = uHasStablePoint * (1.0 - smoothstep(stableRadius * 0.52, stableRadius, stableDistance)) * (1.0 - bodyRegionExclusion);
   float ring = sin((distance(transformed, uHoverPoint) * 18.0) - (uTime * 7.0));
   float fullBodyWave = sin(uTime * 3.2 + transformed.y * 2.4 + transformed.x * 1.5 + transformed.z * 1.2);
   float hoverStability = 1.0 - vEntangledHover;
@@ -1193,20 +1420,21 @@ void main() {`,
     shader.fragmentShader = shader.fragmentShader
       .replace(
         "void main() {",
-        `
-uniform float uBaseOpacity;
-varying float vEntangledHover;
-varying float vStableReveal;
+	        `
+	uniform float uBaseOpacity;
+	varying float vEntangledHover;
+	varying float vStableReveal;
+varying float vBodyRegionId;
 
 void main() {`,
-      )
-      .replace(
-        "#include <opaque_fragment>",
-        `float hoverOpacity = mix(uBaseOpacity, 0.86, vEntangledHover);
-float revealOpacity = mix(hoverOpacity, 1.0, vStableReveal);
-diffuseColor.a = clamp(revealOpacity, 0.08, 1.0);
-#include <opaque_fragment>`,
-      );
+	      )
+	      .replace(
+		        "#include <opaque_fragment>",
+	        `float hoverOpacity = mix(uBaseOpacity, 0.86, vEntangledHover);
+	float revealOpacity = mix(hoverOpacity, 1.0, vStableReveal);
+	diffuseColor.a = clamp(revealOpacity, 0.08, 1.0);
+	#include <opaque_fragment>`,
+	      );
   };
   material.needsUpdate = true;
   return material;
@@ -1222,6 +1450,8 @@ const reusableFixedPathEnd = new Vector3();
 const reusableSamplePoint = new Vector3();
 const reusableSurfaceHover = new Vector3();
 const reusableSurfaceInteraction = new Vector3();
+const reusableSurfaceZeroBitMask = new Vector3();
+const reusableZeroBitMaskPoint = new Vector3();
 const reusableNerveTarget = new Vector3();
 const reusablePointOnNervePath = new Vector3();
 const reusableCandidateOnNervePath = new Vector3();

--- a/apps/web/components/OriginalGlbModel.tsx
+++ b/apps/web/components/OriginalGlbModel.tsx
@@ -1133,11 +1133,24 @@ function pointCloudRegionSpatialOverride(x: number, y: number, z: number, minY: 
   const backThreshold = minZ + depth * 0.47;
   const absX = Math.abs(x);
 
+  if (isPointCloudHandPoint(absX, y, normalizedY)) return x < 0 ? regionToId("rightHand") : regionToId("leftHand");
   if (z < backThreshold && normalizedY > 0.48) return regionToId("oxygenTank");
-  if (absX > 2.95 && y > 5.05 && y < 7.3) return x < 0 ? regionToId("rightHand") : regionToId("leftHand");
   if (absX > 1.95 && absX <= 3.35 && y > 6.35 && y < 9.25) return x < 0 ? regionToId("rightArm") : regionToId("leftArm");
   if (absX > 1.0 && absX <= 2.35 && y > 8.1 && y < 9.5 && z > -0.75) return x < 0 ? regionToId("rightShoulder") : regionToId("leftShoulder");
+  if (isPointCloudChestPoint(absX, y, normalizedY)) return regionToId("chest");
   return null;
+}
+
+function isPointCloudHandPoint(absX: number, y: number, normalizedY: number): boolean {
+  const inLowHandBand = absX > 2.15 && normalizedY > 0.36 && normalizedY < 0.56;
+  const inModelHandBand = absX > 2.55 && y > 4.8 && y < 7.55;
+  return inLowHandBand || inModelHandBand;
+}
+
+function isPointCloudChestPoint(absX: number, y: number, normalizedY: number): boolean {
+  const inCentralUpperBand = absX <= 1.05 && normalizedY > 0.58 && normalizedY < 0.76;
+  const inModelChestBand = absX <= 1.18 && y > 7.05 && y < 9.35;
+  return inCentralUpperBand || inModelChestBand;
 }
 
 function bodyRegionIdForBoneName(boneName: string): number {
@@ -1190,6 +1203,7 @@ function bodyRegionIdForVertex(boneName: string, x: number, y: number, z: number
   if (lower.includes("spine") || lower.includes("master") || lower.includes("root")) return regionToId("torso");
 
   if (normalizedY > 0.78) return regionToId("head");
+  if (Math.abs(x) <= 1.05 && normalizedY > 0.58) return regionToId("chest");
   if (normalizedY > 0.6) return x < 0 ? regionToId("rightShoulder") : regionToId("leftShoulder");
   if (normalizedY > 0.42) return regionToId("torso");
   return x < 0 ? regionToId("rightLeg") : regionToId("leftLeg");
@@ -1238,7 +1252,7 @@ function prepareMaskedPointMaterial({
     transparent: true,
     opacity,
     blending,
-    depthTest: true,
+    depthTest: false,
     depthWrite: false,
   }) as MaskedPointMaterial;
 
@@ -1329,7 +1343,9 @@ function updateMaskedPointMaterial(
   stableProgress: number,
   excludedRegionMask: Float32Array,
 ): void {
-  material.opacity = opacity;
+  const hasExcludedRegions = hasActiveRegionMask(excludedRegionMask);
+  material.opacity = hasExcludedRegions ? Math.max(opacity, 0.62) : opacity;
+  material.depthTest = false;
 
   const uniforms = material.userData.hoverMaskUniforms;
   if (!uniforms) return;
@@ -1343,6 +1359,13 @@ function updateMaskedPointMaterial(
     scene.worldToLocal(reusableSurfaceInteraction);
     uniforms.uHiddenPoint.value = reusableSurfaceInteraction;
   }
+}
+
+function hasActiveRegionMask(mask: Float32Array): boolean {
+  for (let index = 0; index < mask.length; index += 1) {
+    if (mask[index] > 0.5) return true;
+  }
+  return false;
 }
 
 function prepareMaterial(source: Material, opacity: number): WaveMaterial {

--- a/apps/web/lib/bodyRegions.ts
+++ b/apps/web/lib/bodyRegions.ts
@@ -1,23 +1,10 @@
 import type { Vector3Tuple } from "three";
 
-export const BODY_REGIONS = [
-  "head",
-  "chest",
-  "torso",
-  "oxygenTank",
-  "rightShoulder",
-  "leftShoulder",
-  "rightArm",
-  "leftArm",
-  "rightHand",
-  "leftHand",
-  "rightLeg",
-  "leftLeg",
-  "rightFoot",
-  "leftFoot",
-] as const;
+import bodyRegionMap from "../../api/data/body_region_map.json";
 
-export type BodyRegion = (typeof BODY_REGIONS)[number];
+export type BodyRegion = (typeof bodyRegionMap.regions)[number]["id"];
+
+export const BODY_REGIONS = bodyRegionMap.regions.map((region) => region.id) as BodyRegion[];
 
 export type RegionState = {
   activation: number;

--- a/apps/web/lib/quantumClient.ts
+++ b/apps/web/lib/quantumClient.ts
@@ -6,6 +6,10 @@ const REQUEST_TIMEOUT_MS = parsePositiveInteger(
   process.env.NEXT_PUBLIC_QUANTUM_REQUEST_TIMEOUT_MS,
   300000,
 );
+const FALLBACK_ON_HTTP_ERRORS = parseBoolean(
+  process.env.NEXT_PUBLIC_QUANTUM_FALLBACK_ON_HTTP_ERRORS,
+  false,
+);
 
 export type QuantumInteraction = "hover" | "click" | "hold";
 export type QuantumBackend = "aer" | "ionq_simulator" | "ionq_hardware";
@@ -126,6 +130,7 @@ async function requestJsonWithFallback(url: string, init: RequestInit, fallback:
 function shouldUseLocalFallback(error: unknown): boolean {
   if (error instanceof TypeError) return true;
   if (!(error instanceof Error)) return false;
+  if (isHttpServerResponse(error.message)) return FALLBACK_ON_HTTP_ERRORS;
   return (
     error.message.includes("Failed to fetch") ||
     error.message.includes("Load failed") ||
@@ -133,12 +138,20 @@ function shouldUseLocalFallback(error: unknown): boolean {
     error.message.includes("socket hang up") ||
     error.message.includes("ECONNRESET") ||
     error.message.includes("Request failed with 404") ||
-    error.message.includes("Request failed with 500") ||
     error.message.includes("Request failed with 502") ||
     error.message.includes("Request failed with 503") ||
-    error.message.includes("Request failed with 504") ||
-    error.message.includes("Request failed with 403") ||
-    error.message.includes("Request failed with 405")
+    error.message.includes("Request failed with 504")
+  );
+}
+
+function isHttpServerResponse(message: string): boolean {
+  return (
+    message.includes("Request failed with 400") ||
+    message.includes("Request failed with 401") ||
+    message.includes("Request failed with 403") ||
+    message.includes("Request failed with 405") ||
+    message.includes("Request failed with 422") ||
+    message.includes("Request failed with 500")
   );
 }
 
@@ -241,4 +254,9 @@ function parsePositiveInteger(value: string | undefined, fallback: number): numb
   if (!value) return fallback;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!value) return fallback;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,7 @@ IONQ_SIMULATOR_BACKEND=ionq_simulator
 IONQ_QPU_BACKEND=ionq_qpu
 IONQ_ENABLE_HARDWARE=false
 IONQ_TIMEOUT_SECONDS=120
+API_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://entangledbody.com
 ```
 
 IonQ hardware execution only submits to a QPU when `IONQ_API_KEY` is set and `IONQ_ENABLE_HARDWARE=true`. Otherwise, IonQ requests return an Aer fallback payload with `fallbackReason`.
@@ -107,7 +108,10 @@ Frontend environment variables:
 ```text
 NEXT_PUBLIC_API_BASE_URL=/api
 NEXT_PUBLIC_QUANTUM_REQUEST_TIMEOUT_MS=300000
+NEXT_PUBLIC_QUANTUM_FALLBACK_ON_HTTP_ERRORS=false
 ```
+
+Set `NEXT_PUBLIC_QUANTUM_FALLBACK_ON_HTTP_ERRORS=true` only when a demo should use bundled local samples even after backend HTTP errors. Keep it false while debugging so API 4xx/5xx responses surface in the UI.
 
 For local development without the Next.js rewrite, point the browser directly at the API:
 
@@ -163,7 +167,7 @@ Run backend smoke tests:
 
 ```bash
 cd apps/api
-python -m pytest tests/smoke_quantum_backends.py -q
+../../.venv/bin/python -m unittest tests.smoke_quantum_backends -q
 ```
 
 The smoke tests cover:
@@ -181,7 +185,7 @@ cd apps/api
 IONQ_API_KEY=your-ionq-api-key \
 IONQ_ENABLE_HARDWARE=true \
 RUN_IONQ_HARDWARE_TEST=true \
-python -m pytest tests/smoke_quantum_backends.py::IonQHardwareIntegrationTests::test_real_ionq_hardware_execution_when_explicitly_enabled -q
+../../.venv/bin/python -m unittest tests.smoke_quantum_backends.IonQHardwareIntegrationTests.test_real_ionq_hardware_execution_when_explicitly_enabled -q
 ```
 
 Frontend automated tests are not currently documented.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,9 +1027,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1484,9 +1484,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@react-three/fiber": "^9.1.0",
         "@types/three": "^0.176.0",
-        "codex": "^0.2.3",
-        "next": "^15.3.1",
+        "next": "^15.5.18",
         "node": "^24.15.0",
         "pytest": "^1.0.0",
         "react": "^19.1.0",
@@ -517,15 +516,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -539,9 +538,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +554,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -571,9 +570,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -587,9 +586,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -603,9 +602,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -619,9 +618,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +634,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -828,35 +827,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
@@ -883,86 +853,11 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/codex": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/codex/-/codex-0.2.3.tgz",
-      "integrity": "sha512-+MQbh3UIJRZFawxQUgPAEXKyL9o06fy8JmrgW4EnMeMlj8kh3Jljh4+CcOdH9yt82FTkmEwUR2qOrOev3ZoJJA==",
-      "dependencies": {
-        "connect": "1.8.x",
-        "dox": "0.3.x",
-        "drip": "0.2.x",
-        "fez": "0.0.x",
-        "highlight.js": "1.2.x",
-        "jade": "0.26.x",
-        "marked": "0.2.x",
-        "ncp": "0.2.x",
-        "nib": "0.4.x",
-        "oath": "0.2.x",
-        "optimist": "0.3.x",
-        "rimraf": "2.0.x",
-        "stylus": "0.26.x",
-        "tea": "0.0.x",
-        "yaml": "0.2.x"
-      },
-      "bin": {
-        "codex": "bin/codex"
-      },
-      "engines": {
-        "node": ">= 0.4.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
-      "engines": {
-        "node": ">= 0.4.x"
-      }
-    },
-    "node_modules/connect": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-1.8.7.tgz",
-      "integrity": "sha512-j72iQ8i6td2YLZD37ADpGOa4C5skHNrJSGQkJh/t+DCoE6nm8NbHslFTs17q44EJsiVrry+W13yrxd46M32jbA==",
-      "deprecated": "connect 1.x series is deprecated",
-      "dependencies": {
-        "formidable": "1.0.x",
-        "mime": ">= 0.0.1",
-        "qs": ">= 0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.4.1 < 0.7.0"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.2.5.tgz",
-      "integrity": "sha512-b9ecqKEfWrNcyzx5+1nmcfi80fPp8dVM8rlAh7fFK14PZbNjp++gRjyZTZfLJQa/Lw0qeCJho7WBIl0nw0v6HA==",
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -974,209 +869,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/dox": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/dox/-/dox-0.3.3.tgz",
-      "integrity": "sha512-5bSKbTcpFm+0wPRnxMkJhY5dFoWWxsTQdTLFg2d1HyLl0voy9GoBVVOKM+yPSdTdKCXrHqwEwUcdS7s4BTst7w==",
-      "dependencies": {
-        "commander": "0.6.1",
-        "github-flavored-markdown": ">= 0.0.1"
-      },
-      "bin": {
-        "dox": "bin/dox"
-      }
-    },
-    "node_modules/drip": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/drip/-/drip-0.2.4.tgz",
-      "integrity": "sha512-/qhB7CjfmfZYHue9SwicWNqsSp1DNzkHTCVsud92Tb43qKTiIAXBHIdCJYUn93r7MScM++H+nimkWPmvNTg/Qw==",
-      "engines": {
-        "node": ">= 0.4.8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/fez": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/fez/-/fez-0.0.3.tgz",
-      "integrity": "sha512-W+igVHjiRB4ai7h25ay/7OYNwI8IihdABOnRIS3Bcm4UxEWKoenCB6m68HLSq41TxZwbnqzFAqlz/CjKB3rTvg==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
-    },
-    "node_modules/formidable": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-      "integrity": "sha512-95MFT5qipMvUiesmuvGP1BI4hh5XWCzyTapiNJ/k8JBQda7rPy7UCWYItz2uZEdTgGNy1eInjzlL9Wx1O9fedg==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/github-flavored-markdown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/github-flavored-markdown/-/github-flavored-markdown-1.0.1.tgz",
-      "integrity": "sha512-qkpFaYzQ+JbZw7iuZCpvjqas5E8ZNq/xuTtBtdPkAlowX8VXBmkZE2DCgNGCTW5KZsCvqX5lSef/2yrWMTztBQ==",
-      "deprecated": "This project is long out of date. Use 'marked' instead.",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz",
-      "integrity": "sha512-JUrvoFoQbLZpOZilKTXZX2e1EV0DTnuG5vsRFNFv4mPf/mnYbwNAFw/5x0rxeyaJslIdObGSgTTsMnM/acRaVw==",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "license": "BSD",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-1.2.0.tgz",
-      "integrity": "sha512-k19Rm9OuIGiZvD+0G2Lao6kPr01XMEbEK67/n+GqOMTgxc7HhgzfLzX71Q9j5Qu+bkzYXbPFHums8tl0dzV4Uw==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
-      "dependencies": {
-        "commander": "*"
-      },
-      "bin": {
-        "hljs": "bin/hljs"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1210,83 +907,16 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
-      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
-      "dependencies": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "bin": {
-        "jade": "bin/jade"
-      }
-    },
-    "node_modules/marked": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.2.10.tgz",
-      "integrity": "sha512-LyFB4QvdBaJFfEIn33plrxtBuRjeHoDE2QJdP58i2EWMUTpa6GK6MnjJh3muCvVibFJompyr6IxecK2fjp4RDw==",
-      "bin": {
-        "marked": "bin/marked"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/meshoptimizer": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
       "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
       "license": "MIT"
     },
-    "node_modules/mime": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
-      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
-      "license": "MIT",
-      "bin": {
-        "mime": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "license": "MIT/X11",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nan": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
-      "integrity": "sha512-Wm2/nFOm2y9HtJfgOLnctGbfvF23FcQZeyUZqDD8JQG3zO5kXh3MkQKiUaA68mJiVWrOzLFkAV1u6bC8P52DJA==",
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -1301,22 +931,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/ncp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.2.7.tgz",
-      "integrity": "sha512-wPUepcV37u3Mw+ktjrUbl3azxwAkcD9RrVLQGlpSapWcEQM5jL0g8zwKo6ukOjVQAAEjqpRdLeojOalqqySpCg==",
-      "license": "MIT",
-      "bin": {
-        "ncp": "bin/ncp"
-      }
-    },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -1329,14 +950,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -1362,14 +983,6 @@
         }
       }
     },
-    "node_modules/nib": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/nib/-/nib-0.4.1.tgz",
-      "integrity": "sha512-q8n5RAcLLpA5YewcH9UplGzPTu4XbC6t9hVPB1RsnvKD5aYWT+V+2NHGH/dgw/6YDjgETEa7hY54kVhvn1i5DQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/node": {
       "version": "24.15.0",
       "resolved": "https://registry.npmjs.org/node/-/node-24.15.0.tgz",
@@ -1390,56 +1003,6 @@
       "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
       "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA=="
     },
-    "node_modules/oath": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/oath/-/oath-0.2.3.tgz",
-      "integrity": "sha512-/uTqn2KKy671SunNXhULGbumn2U3ZN84LvYZdnfSqqqBkM6cppm+jcUodWELd9CYVNYGh6QwJEEAQ0WM95qjpA==",
-      "engines": {
-        "node": ">= 0.4.8"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/orchid": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/orchid/-/orchid-0.0.3.tgz",
-      "integrity": "sha512-jkbcOxPnbo9M0WZbvjvTKLY+2lhxyWnoJXKESHodJAD00bsqOe5YPrJZ2rjgBKJ4YIgmbKSMlsjNIZ8NNhXbOA==",
-      "dependencies": {
-        "drip": "0.2.x",
-        "oath": "0.2.x",
-        "ws": "0.4.x"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1447,9 +1010,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1466,9 +1029,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1481,21 +1044,6 @@
       "license": "ISC",
       "bin": {
         "start11": "test.js"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react": {
@@ -1532,16 +1080,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.0.3.tgz",
-      "integrity": "sha512-uR09PSoW2+1hW0hquRqxb+Ae2h6R5ls3OAy2oNekQFtqbSJkltkhKRa+OhZKoxWsN9195Gp1vg7sELDRoJ8a3w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "~1.1"
       }
     },
     "node_modules/scheduler": {
@@ -1608,78 +1146,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1712,22 +1178,6 @@
         }
       }
     },
-    "node_modules/stylus": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.26.1.tgz",
-      "integrity": "sha512-33J3iBM2Ueh/wDFzkQXmjHSDxNRWQ7J2I2dqiInAKkGR4j+3hkojRRSbv3ITodxJBIodVfv0l10CHZhJoi0Ubw==",
-      "dependencies": {
-        "cssom": "0.2.x",
-        "debug": "*",
-        "mkdirp": "0.3.x"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/suspend-react": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
@@ -1737,32 +1187,11 @@
         "react": ">=17.0"
       }
     },
-    "node_modules/tea": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/tea/-/tea-0.0.13.tgz",
-      "integrity": "sha512-wpVkMmrK83yrwjnBYtN/GKzA0ixt1k68lq4g0s0H38fZTPHeApnToCVzpQgDEToNoBbviHQaOhXcMldHnM+XwQ==",
-      "dependencies": {
-        "drip": "0.2.x",
-        "oath": "0.2.x",
-        "orchid": "0.0.x"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/three": {
       "version": "0.176.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.176.0.tgz",
       "integrity": "sha512-PWRKYWQo23ojf9oZSlRGH8K09q7nRSWx6LY/HF/UUrMdYgN9i1e2OwJYHoQjwc6HF/4lvvYLC5YC1X8UJL2ZpA==",
       "license": "MIT"
-    },
-    "node_modules/tinycolor": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-      "integrity": "sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1798,49 +1227,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "0.4.32",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
-      "integrity": "sha512-htqsS0U9Z9lb3ITjidQkRvkLdVhQePrMeu475yEfOWkAYvJ6dSjQp1tOH6ugaddzX5b7sQjMPNtY71eTzrV/kA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "commander": "~2.1.0",
-        "nan": "~1.0.0",
-        "options": ">=0.0.5",
-        "tinycolor": "0.x"
-      },
-      "bin": {
-        "wscat": "bin/wscat"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ws/node_modules/commander": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-      "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
-      "integrity": "sha512-LzdhmhritYCRww8GLH95Sk5A2c18ddRQMeooOUnqWkDUnBbmVfqgg2fXH2MxAHYHCVTHDK1EEbmgItQ8kOpM0Q==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@react-three/fiber": "^9.1.0",
     "@types/three": "^0.176.0",
-    "codex": "^0.2.3",
-    "next": "^15.3.1",
+    "next": "^15.5.18",
     "node": "^24.15.0",
     "pytest": "^1.0.0",
     "react": "^19.1.0",
@@ -27,5 +26,8 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
• ## Summary

  Added frontend logic so body regions measured as qubit 0 remain visible as
  3D point-cloud remnants instead of fully collapsing into the solid mesh.
  Also fixed point-cloud region masking for hands and chest, increased 0
  result likelihood slightly in measurement mode, shared frontend region IDs
  from body_region_map.json, hardened API fallback/CORS behavior, and
  resolved npm audit dependency issues.

  ## Related Issue

  Closes #

  ## Type

  - [x] Feature
  - [x] Bug fix
  - [x] Refactor
  - [x] Docs
  - [x] Chore

  ## Checklist

  - [x] npm run typecheck passes
  - [x] npm run build passes
  - [x] Tested locally
  - [x] Verified in preview deployment
  - [x] No secrets exposed
  - [x] Docs updated if needed

  ## Screenshots / Video

  Visual change: regions measured as 0, including right hand, left hand,
  chest, and torso, now remain as point-cloud remnants while 1 regions
  collapse into the opaque body mesh.

  ## Notes for Reviewer

  Focus on the measurement collapse rendering path, especially
  zeroBitRegions, point-cloud region classification, and fallback behavior.
  Also note that CORS and frontend HTTP fallback behavior are now
  environment-configurable.