### PR TITLE
Improve intro controls and mute shortcut

### DIFF
--- a/apps/web/components/BodyScene.tsx
+++ b/apps/web/components/BodyScene.tsx
@@ -318,7 +318,7 @@ export function BodyScene() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() !== "m" || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.code !== "KeyM" || event.metaKey || event.ctrlKey || event.altKey) return;
 
       const target = event.target;
       if (

--- a/apps/web/components/LoadingIntro.tsx
+++ b/apps/web/components/LoadingIntro.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 
 const INTRO_LINES = [
   "Everything is in a quantum state.",
@@ -58,35 +58,39 @@ export function LoadingIntro({ modelReady, onComplete, onExitStart, visible }: L
     return () => window.clearTimeout(timeout);
   }, [currentLine, typedLength, visible]);
 
+  const advanceIntro = useCallback(() => {
+    void resumeTypingAudio(audioContextRef);
+
+    if (typedLength < currentLine.length) {
+      setTypedLength(currentLine.length);
+      return;
+    }
+
+    if (lineIndex >= INTRO_LINES.length - 1) {
+      if (modelReady && !exiting) {
+        onExitStart?.();
+        setExiting(true);
+        window.setTimeout(onComplete, INTRO_FADE_OUT_MS);
+      }
+      return;
+    }
+
+    setLineIndex((index) => index + 1);
+    setTypedLength(0);
+  }, [currentLine.length, exiting, lineIndex, modelReady, onComplete, onExitStart, typedLength]);
+
   useEffect(() => {
     if (!visible) return;
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key !== "Enter") return;
       event.preventDefault();
-      void resumeTypingAudio(audioContextRef);
-
-      if (typedLength < currentLine.length) {
-        setTypedLength(currentLine.length);
-        return;
-      }
-
-      if (lineIndex >= INTRO_LINES.length - 1) {
-        if (modelReady && !exiting) {
-          onExitStart?.();
-          setExiting(true);
-          window.setTimeout(onComplete, INTRO_FADE_OUT_MS);
-        }
-        return;
-      }
-
-      setLineIndex((index) => index + 1);
-      setTypedLength(0);
+      advanceIntro();
     }
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [currentLine.length, exiting, lineIndex, modelReady, onComplete, onExitStart, typedLength, visible]);
+  }, [advanceIntro, visible]);
 
   if (!visible) return null;
   const isTitleLine = lineIndex === INTRO_LINES.length - 1;
@@ -95,7 +99,17 @@ export function LoadingIntro({ modelReady, onComplete, onExitStart, visible }: L
   const [title, subtitle = ""] = visibleTitle.split("\n");
 
   return (
-    <section className={exiting ? "loading-intro loading-intro--exiting" : "loading-intro"} aria-live="polite" aria-label="3D model loading introduction">
+    <section
+      className={exiting ? "loading-intro loading-intro--exiting" : "loading-intro"}
+      aria-live="polite"
+      aria-label="3D model loading introduction"
+      role="button"
+      tabIndex={0}
+      onPointerUp={(event) => {
+        if (event.button !== 0) return;
+        advanceIntro();
+      }}
+    >
       <div className="loading-intro__stars" aria-hidden="true">
         {stars.map((star) => (
           <i


### PR DESCRIPTION
## Summary
- Update the mute/unmute shortcut to use the physical `M` key position so it works across keyboard languages
- Allow the loading intro to advance with screen click/tap in addition to Enter
- Improve mobile intro navigation by supporting pointer input


## Checklist
- [x] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally
- [ ] Verified in preview deployment
- [ ] No secrets exposed
- [ ] Docs updated if needed
